### PR TITLE
Bitmap 32/16/8 hot fix

### DIFF
--- a/src/raster/bmap_16.s
+++ b/src/raster/bmap_16.s
@@ -62,12 +62,17 @@ _plot_bitmap_16:
         mulu.w  #80,d0                          ; screen width in bytes
         adda.l  d0,a0                           ; add row offset
                 
-                ; Calculate and add col offset: col / 8 (pixels to bytes)
-        move.w  col(a6),d0
-        lsr.w   #3,d0                           ; divide by 8 (shift right 3 bits)
-        ext.l   d0                              ; extend to long
-        adda.l  d0,a0                           ; add col offset in bytes
+                ; Calculate col byte offset and bit shift
+        move.w  col(a6),d6                      ; d6 = col (pixel column)
+        move.w  d6,d5                           ; copy for bit calculation
+        lsr.w   #3,d6                           ; d6 = col / 8 (byte offset)
+        ext.l   d6
+        adda.l  d6,a0                           ; add col offset in bytes
                 
+        andi.w  #7,d5                           ; d5 = col % 8 (bit shift amount)
+        bne     unaligned_copy                  ; if not 0, need bit shifting
+                
+                ; BYTE-ALIGNED PATH (col % 8 == 0)
                 ; Check long word alignment for optimization
         move.l  a0,d1
         btst    #0,d1                           ; test if start address is odd
@@ -135,6 +140,58 @@ byte_loop: move.b (a1)+,(a0)+                   ; copy first byte
         move.b  (a1)+,(a0)                      ; copy second byte
         adda.w  #79,a0                          ; move to next row (80 - 1 already advanced)
         dbra    d7,byte_loop
+                
+        movem.l (sp)+,d0-d7/a0-a5
+        unlk    a6
+        rts
+
+unaligned_copy:
+                ; NON-BYTE-ALIGNED PATH (col % 8 != 0)
+                ; Need to shift bitmap and write across 3 bytes per row
+                ; d5 = bit shift amount (1-7)
+                ; a0 = screen start position
+                ; a1 = bitmap data
+                
+        move.w  height(a6),d7                   ; get height
+        subq.w  #1,d7                           ; adjust for dbra
+                
+                ; Calculate (8-d5) for left shifting
+        moveq   #8,d6
+        sub.w   d5,d6                           ; d6 = 8 - bit_shift
+                
+shift_loop_16:
+                ; Load 16-bit bitmap data
+        moveq   #0,d0
+        move.w  (a1)+,d0                        ; d0 = bitmap word (16 pixels)
+                
+                ; Extract bits that will overflow into the 3rd byte
+        move.l  d0,d1                           ; copy bitmap to d1
+        lsl.l   d6,d1                           ; shift left to move overflow bits to high position
+                ; d1 now has the overflow bits in the low byte
+                
+                ; Shift the main bitmap data right by bit_shift
+        lsr.l   d5,d0                           ; shift right by bit_shift
+                
+                ; Byte 0 (leftmost) - needs masking to preserve high bits
+        moveq   #-1,d4                          ; start with all 1s
+        lsl.w   d6,d4                           ; shift left by (8-d5) to create mask for high bits
+        and.b   d4,(a0)                         ; preserve the high bits
+        move.l  d0,d3                           ; copy to d3
+        lsr.l   #8,d3                           ; shift right 8 bits to get high byte
+        or.b    d3,(a0)                         ; OR into screen byte 0
+                
+                ; Byte 1 (middle) - fully overwritten, must clear first!
+        clr.b   1(a0)                           ; clear the byte first
+        or.b    d0,1(a0)                        ; OR into screen byte 1 (low byte of d0)
+                
+                ; Byte 2 (rightmost) - needs masking to preserve low bits
+        move.l  #$ff,d4                         ; start with 0x000000FF
+        lsr.l   d5,d4                           ; shift right by d5 to create mask for low bits
+        and.b   d4,2(a0)                        ; preserve the low bits
+        or.b    d1,2(a0)                        ; OR overflow bits into screen byte 2
+                
+        adda.w  #80,a0                          ; move to next row
+        dbra    d7,shift_loop_16
                 
         movem.l (sp)+,d0-d7/a0-a5
         unlk    a6

--- a/src/raster/bmap_16.s
+++ b/src/raster/bmap_16.s
@@ -180,7 +180,7 @@ shift_loop_16:
         lsr.l   #8,d3                           ; shift right 8 bits to get high byte
         or.b    d3,(a0)                         ; OR into screen byte 0
                 
-                ; Byte 1 (middle) - fully overwritten, must clear first!
+                ; Byte 1 (middle) - fully overwritten
         clr.b   1(a0)                           ; clear the byte first
         or.b    d0,1(a0)                        ; OR into screen byte 1 (low byte of d0)
                 

--- a/src/raster/bmap_32.s
+++ b/src/raster/bmap_32.s
@@ -274,7 +274,7 @@ shift_loop_32:
         or.b    d0,3(a0)                        ; OR into screen byte 3 (low byte of d0)
                 
                 ; Byte 4 (rightmost, overflow bits) - needs masking to preserve low bits
-        move.l  #$ff,d4                         ; start with 0x000000FF
+        move.l  #$ff,d4                         ; start with 0x0000FF
         lsr.l   d5,d4                           ; shift right by d5 to create mask for low (8-d5) bits
         and.b   d4,4(a0)                        ; preserve the low bits
                 ; d1 already has overflow bits in low byte bits 7-5 from the lsl.l above

--- a/src/raster/bmap_32.s
+++ b/src/raster/bmap_32.s
@@ -61,12 +61,17 @@ _plot_bitmap_32:
         mulu.w  #80,d0                          ; screen width in bytes
         adda.l  d0,a0                           ; add row offset
                 
-                ; Calculate and add col offset: col / 8 (pixels to bytes)
-        move.w  col(a6),d0
-        lsr.w   #3,d0                           ; divide by 8 (shift right 3 bits)
-        ext.l   d0                              ; extend to long
-        adda.l  d0,a0                           ; add col offset in bytes
+                ; Calculate col byte offset and bit shift
+        move.w  col(a6),d6                      ; d6 = col (pixel column)
+        move.w  d6,d5                           ; copy for bit calculation
+        lsr.w   #3,d6                           ; d6 = col / 8 (byte offset)
+        ext.l   d6
+        adda.l  d6,a0                           ; add col offset in bytes
                 
+        andi.w  #7,d5                           ; d5 = col % 8 (bit shift amount)
+        bne     unaligned_copy                  ; if not 0, need bit shifting
+                
+                ; BYTE-ALIGNED PATH (col % 8 == 0)
                 ; Check long word alignment for optimization
         move.l  a0,d1
         btst    #0,d1                           ; test if start address is odd
@@ -134,6 +139,72 @@ byte_loop: move.b (a1)+,(a0)+                   ; copy byte 1
         move.b  (a1)+,(a0)                      ; copy byte 4
         adda.w  #77,a0                          ; move to next row (80 - 3 already advanced)
         dbra    d7,byte_loop
+                
+        movem.l (sp)+,d0-d7/a0-a5
+        unlk    a6
+        rts
+
+unaligned_copy:
+                ; NON-BYTE-ALIGNED PATH (col % 8 != 0)
+                ; Need to shift bitmap and write across 5 bytes per row
+                ; d5 = bit shift amount (1-7)
+                ; a0 = screen start position
+                ; a1 = bitmap data
+                
+        move.w  height(a6),d7                   ; get height
+        subq.w  #1,d7                           ; adjust for dbra
+                
+                ; For 32-bit shifting, we need to use a 64-bit approach
+                ; Load 4 bytes, shift them, and write across 5 bytes
+                
+shift_loop_32:
+                ; Load 32-bit bitmap data
+        move.l  (a1)+,d0                        ; d0 = bitmap long (32 pixels)
+                
+                ; We need to shift d0 right by d5 bits, but this will lose bits
+                ; So we use two registers to catch the overflow
+                                
+                ; First, extract the bits that will overflow into the 5th byte
+        move.l  d0,d1                           ; copy bitmap to d1
+        moveq   #8,d2                           ; d2 = 8
+        sub.w   d5,d2                           ; d2 = 8 - bit_shift
+        lsl.l   d2,d1                           ; shift left to move overflow bits to high position
+                ; d1 now has the bits for the 5th byte in the high bits
+                
+                ; Shift the main bitmap data right by bit_shift
+        lsr.l   d5,d0                           ; shift right by bit_shift
+                ; d0 now has the 32 bits positioned correctly, but in 24+shift bits
+                
+                ; Extract individual bytes and write them using OR
+                ; Byte 0 (leftmost)
+        move.l  d0,d3                           ; copy to d3
+        lsr.l   #8,d3                           ; shift right 24 bits
+        lsr.l   #8,d3
+        lsr.l   #8,d3
+        or.b    d3,(a0)                         ; OR into screen byte 0
+                
+                ; Byte 1
+        move.l  d0,d3
+        lsr.l   #8,d3                           ; shift right 16 bits
+        lsr.l   #8,d3
+        or.b    d3,1(a0)                        ; OR into screen byte 1
+                
+                ; Byte 2
+        move.l  d0,d3
+        lsr.l   #8,d3                           ; shift right 8 bits
+        or.b    d3,2(a0)                        ; OR into screen byte 2
+                
+                ; Byte 3
+        or.b    d0,3(a0)                        ; OR into screen byte 3 (low byte of d0)
+                
+                ; Byte 4 (rightmost, overflow bits)
+        lsr.l   #8,d1                           ; shift right 24 bits
+        lsr.l   #8,d1
+        lsr.l   #8,d1
+        or.b    d1,4(a0)                        ; OR into screen byte 4
+                
+        adda.w  #80,a0                          ; move to next row
+        dbra    d7,shift_loop_32
                 
         movem.l (sp)+,d0-d7/a0-a5
         unlk    a6

--- a/src/raster/bmap_32.s
+++ b/src/raster/bmap_32.s
@@ -105,6 +105,78 @@ movem_loop:                                     ; (happy)
         unlk    a6
         rts
 
+shifted_copy:
+                ; Bit-shifted copy for non-byte-aligned x positions
+                ; Writes 5 destination bytes per row for a 32-bit source row,
+                ; while preserving unaffected bits in first/last destination bytes.
+        moveq   #8,d6
+        sub.w   d5,d6                           ; d6 = (8 - bit_offset)
+
+        move.w  height(a6),d7                   ; get height (number of rows)
+        subq.w  #1,d7                           ; adjust for dbra
+
+shift_row_loop:
+        movea.l a0,a2                           ; row destination pointer
+
+        moveq   #0,d0
+        moveq   #0,d1
+        moveq   #0,d2
+        moveq   #0,d3
+        move.b  (a1)+,d0                        ; b0
+        move.b  (a1)+,d1                        ; b1
+
+                ; out0 = b0 >> shift, merge with first destination byte
+        moveq   #-1,d4
+        lsl.w   d6,d4                           ; keep mask for high bits before sprite start
+        and.b   d4,(a2)
+        move.w  d0,d4
+        lsr.w   d5,d4
+        or.b    d4,(a2)
+        addq.l  #1,a2
+
+                ; out1 = (b0 << (8-shift)) | (b1 >> shift)
+        move.w  d0,d4
+        lsl.w   d6,d4
+        move.w  d1,d3
+        lsr.w   d5,d3
+        or.b    d3,d4
+        move.b  d4,(a2)+
+
+        move.b  (a1)+,d2                        ; b2
+
+                ; out2 = (b1 << (8-shift)) | (b2 >> shift)
+        move.w  d1,d4
+        lsl.w   d6,d4
+        move.w  d2,d3
+        lsr.w   d5,d3
+        or.b    d3,d4
+        move.b  d4,(a2)+
+
+        move.b  (a1)+,d3                        ; b3
+
+                ; out3 = (b2 << (8-shift)) | (b3 >> shift)
+        move.w  d2,d4
+        lsl.w   d6,d4
+        move.w  d3,d0
+        lsr.w   d5,d0
+        or.b    d0,d4
+        move.b  d4,(a2)+
+
+                ; out4 = b3 << (8-shift), merge with last destination byte
+        moveq   #-1,d0
+        lsr.w   d5,d0                           ; keep mask for low bits after sprite end
+        and.b   d0,(a2)
+        move.w  d3,d4
+        lsl.w   d6,d4
+        or.b    d4,(a2)
+
+        adda.w  #80,a0                          ; next screen row
+        dbra    d7,shift_row_loop
+
+        movem.l (sp)+,d0-d7/a0-a5
+        unlk    a6
+        rts
+
 long_copy:
                 ; Check if screen address is word-aligned (even)
         move.l  a0,d1
@@ -133,7 +205,8 @@ byte_copy:                                      ; Byte-by-byte copy for misalign
         move.w  height(a6),d7                   ; get height (number of rows)
         subq.w  #1,d7                           ; adjust for dbra
                 
-byte_loop: move.b (a1)+,(a0)+                   ; copy byte 1
+byte_loop: 
+        move.b  (a1)+,(a0)+                     ; copy byte 1
         move.b  (a1)+,(a0)+                     ; copy byte 2
         move.b  (a1)+,(a0)+                     ; copy byte 3
         move.b  (a1)+,(a0)                      ; copy byte 4
@@ -167,7 +240,7 @@ shift_loop_32:
                 ; First, extract the bits that will overflow into the 5th byte
         move.l  d0,d1                           ; copy bitmap to d1
         moveq   #8,d2                           ; d2 = 8
-        sub.w   d5,d2                           ; d2 = 8 - bit_shift
+        sub.w   d5,d2                           ; d2 = 8 - bit_shift (d2 will be used for masking)
         lsl.l   d2,d1                           ; shift left to move overflow bits to high position
                 ; d1 now has the bits for the 5th byte in the high bits
                 
@@ -176,7 +249,10 @@ shift_loop_32:
                 ; d0 now has the 32 bits positioned correctly, but in 24+shift bits
                 
                 ; Extract individual bytes and write them using OR
-                ; Byte 0 (leftmost)
+                ; Byte 0 (leftmost) - needs masking to preserve high bits
+        moveq   #-1,d4                          ; start with all 1s
+        lsl.w   d2,d4                           ; shift left by (8-d5) to create mask for high bits
+        and.b   d4,(a0)                         ; clear the bits we're about to write
         move.l  d0,d3                           ; copy to d3
         lsr.l   #8,d3                           ; shift right 24 bits
         lsr.l   #8,d3
@@ -197,10 +273,11 @@ shift_loop_32:
                 ; Byte 3
         or.b    d0,3(a0)                        ; OR into screen byte 3 (low byte of d0)
                 
-                ; Byte 4 (rightmost, overflow bits)
-        lsr.l   #8,d1                           ; shift right 24 bits
-        lsr.l   #8,d1
-        lsr.l   #8,d1
+                ; Byte 4 (rightmost, overflow bits) - needs masking to preserve low bits
+        move.l  #$ff,d4                         ; start with 0x000000FF
+        lsr.l   d5,d4                           ; shift right by d5 to create mask for low (8-d5) bits
+        and.b   d4,4(a0)                        ; preserve the low bits
+                ; d1 already has overflow bits in low byte bits 7-5 from the lsl.l above
         or.b    d1,4(a0)                        ; OR into screen byte 4
                 
         adda.w  #80,a0                          ; move to next row

--- a/src/raster/bmap_8.s
+++ b/src/raster/bmap_8.s
@@ -96,7 +96,7 @@ shift_loop: moveq #0,d0                         ; clear d0
         or.b    d0,(a0)                         ; OR bitmap bits into current screen byte
                 
                 ; Write to next byte with masking  
-        move.l  #$ff,d4                         ; start with 0x000000FF
+        move.l  #$ff,d4                         ; start with 0x0000FF
         lsr.l   d5,d4                           ; shift right by d5 to create mask for low bits
         and.b   d4,1(a0)                        ; preserve the low bits
         or.b    d1,1(a0)                        ; OR bitmap bits into next screen byte

--- a/src/raster/bmap_8.s
+++ b/src/raster/bmap_8.s
@@ -75,7 +75,10 @@ _plot_bitmap_8:
         move.w  height(a6),d7                   ; get height
         subq.w  #1,d7                           ; adjust for dbra
                 
-                ; Double bit-shift is basically same as (#8 - bit_offset). Potential for optimizations here, but this might be best.
+                ; Calculate (8-d5) for masking
+        moveq   #8,d6
+        sub.w   d5,d6                           ; d6 = 8 - bit_offset
+                
 shift_loop: moveq #0,d0                         ; clear d0
         move.b  (a1)+,d0                        ; get bitmap byte into low byte
         lsl.w   #8,d0                           ; shift to high byte: 0x00FF --> 0xFF00
@@ -84,11 +87,19 @@ shift_loop: moveq #0,d0                         ; clear d0
                 ; d0 now has: high byte = bits for current screen byte
                 ;             low byte = bits for next screen byte
                 
-                ; Write to current byte
+                ; Write to current byte with masking
+        moveq   #-1,d4                          ; start with all 1s
+        lsl.w   d6,d4                           ; shift left by (8-d5) to create mask for high bits
+        and.b   d4,(a0)                         ; preserve the high bits
         move.b  d0,d1                           ; get low byte (for next screen byte)
         lsr.w   #8,d0                           ; get high byte into low position
-        or.b    d0,(a0)                         ; OR into current screen byte
-        or.b    d1,1(a0)                        ; OR into next screen byte
+        or.b    d0,(a0)                         ; OR bitmap bits into current screen byte
+                
+                ; Write to next byte with masking  
+        move.l  #$ff,d4                         ; start with 0x000000FF
+        lsr.l   d5,d4                           ; shift right by d5 to create mask for low bits
+        and.b   d4,1(a0)                        ; preserve the low bits
+        or.b    d1,1(a0)                        ; OR bitmap bits into next screen byte
                 
         adda.w  #80,a0                          ; move to next row
         dbra    d7,shift_loop

--- a/src/raster/clr_reg.s
+++ b/src/raster/clr_reg.s
@@ -31,6 +31,11 @@ _clear_region:
         link    a6,#0
         movem.l d0-d7/a0-a6,-(sp)
 
+        tst.w   length(a6)                      ; nothing to clear if length == 0
+        beq     done
+        tst.w   width(a6)                       ; nothing to clear if width == 0
+        beq     done
+
         movea.l base(a6),a0                     ; get base address
                 
                 ; Calculate and add row offset: row * 80 bytes
@@ -72,33 +77,106 @@ row_loop_32: move.l d1,(a0)                     ; write 1 long (4 bytes)
         unlk    a6
         rts
 
-unoptimized:    
-                ; Generic clear region - calculate bytes needed for col through col+width-1
-                ; Formula: ceil((col+width)/8) - floor(col/8)
-                
-        move.w  col(a6),d6                      ; get col in pixels
-        add.w   width(a6),d6                    ; d6 = col + width
-        addq.w  #7,d6                           ; d6 = col + width + 7 (for ceiling division)
-        lsr.w   #3,d6                           ; d6 = (col + width + 7) / 8 = ceiling((col+width)/8)
-                
-        move.w  col(a6),d5                      ; get col in pixels  
-        lsr.w   #3,d5                           ; d5 = col / 8 = floor(col/8)
-                
-        sub.w   d5,d6                           ; d6 = ceiling - floor = num_bytes
-        subq.w  #1,d6                           ; adjust for dbra
-                
-        move.w  length(a6),d7                   ; outer loop: rows (in pixels)
+unoptimized:
+                ; Generic clear with edge masking for non-byte-aligned regions.
+                ; d2 = start_bit (col % 8)
+                ; d3 = end_bit ((col + width) % 8)
+                ; d6 = num_bytes = ceil((start_bit + width)/8)
+
+        move.w  col(a6),d2
+        andi.w  #7,d2                           ; d2 = start_bit
+
+        move.w  col(a6),d3
+        add.w   width(a6),d3
+        andi.w  #7,d3                           ; d3 = end_bit
+
+        move.w  d2,d6
+        add.w   width(a6),d6
+        addq.w  #7,d6
+        lsr.w   #3,d6                           ; d6 = number of bytes touched per row
+
+        move.w  length(a6),d7
         subq.w  #1,d7                           ; adjust for dbra
-                
-row_loop: movea.l a0,a1                         ; save row start position
-        move.w  d6,d5                           ; restore column counter
-                
-col_loop: clr.b (a1)+                           ; clear one byte, advance
-        dbra    d5,col_loop
-                
-        adda.w  #80,a0                          ; move to next row
+
+row_loop:
+        movea.l a0,a1                           ; row start pointer
+        move.w  d6,d5                           ; d5 = bytes remaining in this row
+
+        cmpi.w  #1,d5
+        beq     single_byte_row
+
+                ; First byte: partial clear if start_bit != 0, else full clear
+        tst.w   d2
+        beq     first_full_byte
+        moveq   #-1,d4
+        moveq   #8,d0
+        sub.w   d2,d0                           ; d0 = 8 - start_bit
+        lsl.w   d0,d4                           ; keep high bits before region start
+        and.b   d4,(a1)+
+        subq.w  #1,d5
+        bra     after_first_byte
+
+first_full_byte:
+        clr.b   (a1)+
+        subq.w  #1,d5
+
+after_first_byte:
+                ; Reserve last byte if it is partial
+        tst.w   d3
+        beq     clear_middle_and_last_full
+        subq.w  #1,d5
+
+clear_middle_partial_last:
+        tst.w   d5
+        beq     apply_last_partial
+clear_middle_partial_last_loop:
+        clr.b   (a1)+
+        subq.w  #1,d5
+        bne     clear_middle_partial_last_loop
+
+apply_last_partial:
+        move.w  #$00ff,d4
+        lsr.w   d3,d4                           ; keep low bits after region end
+        and.b   d4,(a1)
+        bra     next_row
+
+clear_middle_and_last_full:
+        tst.w   d5
+        beq     next_row
+clear_middle_and_last_full_loop:
+        clr.b   (a1)+
+        subq.w  #1,d5
+        bne     clear_middle_and_last_full_loop
+        bra     next_row
+
+single_byte_row:
+                ; Region fits in one byte: preserve bits before start and after end.
+                ; preserve_mask = high_preserve | low_preserve
+        moveq   #0,d4
+
+        tst.w   d2
+        beq     single_skip_high
+        moveq   #-1,d0
+        moveq   #8,d1
+        sub.w   d2,d1                           ; d1 = 8 - start_bit
+        lsl.w   d1,d0                           ; high_preserve
+        or.w    d0,d4
+
+single_skip_high:
+        tst.w   d3
+        beq     single_apply
+        move.w  #$00ff,d0
+        lsr.w   d3,d0                           ; low_preserve
+        or.w    d0,d4
+
+single_apply:
+        and.b   d4,(a1)
+
+next_row:
+        adda.w  #80,a0
         dbra    d7,row_loop
-                
+
+done:
         movem.l (sp)+,d0-d7/a0-a6
         unlk    a6
         rts

--- a/src/raster/plt_chr.s
+++ b/src/raster/plt_chr.s
@@ -34,7 +34,7 @@ CHAR_BYTES equ  16                              ; 16 bytes per character
 
 _plot_character:
         link    a6,#0
-        movem.l d0-d7/a0-a5,-(sp)
+        movem.l d0-d3/a0-a1,-(sp)
 
                 ; Get character code and calculate font offset
         move.w  ch(a6),d0                       ; get character code
@@ -66,7 +66,7 @@ _plot_character:
         lea     14(sp),sp                       ; clean up parameters
                 
 done:
-        movem.l (sp)+,d0-d7/a0-a5
+        movem.l (sp)+,d0-d3/a0-a1
         unlk    a6
         rts
 

--- a/src/raster/plt_str.s
+++ b/src/raster/plt_str.s
@@ -28,7 +28,7 @@ CHAR_WIDTH equ  8                               ; characters are 8 pixels wide
 
 _plot_string:
         link    a6,#0
-        movem.l d0-d7/a0-a5,-(sp)
+        movem.l d0-d3/a0-a1,-(sp)
 
         move.l  str(a6),a5                      ; get string pointer into preserved register
         move.w  col(a6),d6                      ; current column position
@@ -54,7 +54,7 @@ char_loop:
         bra     char_loop
                 
 done:
-        movem.l (sp)+,d0-d7/a0-a5
+        movem.l (sp)+,d0-d3/a0-a1
         unlk    a6
         rts
 

--- a/src/raster/test.c
+++ b/src/raster/test.c
@@ -810,12 +810,11 @@ void test_plot_bitmap_32(UINT8 *base)
     plot_bitmap_32(base, 140, 0, smiley_32, 15);
 
     /* Test 8: Various positions testing alignment */
-    plot_bitmap_32(base, 170, 100, arrow_32, 37);
-    plot_bitmap_32(base, 202, 101, arrow_32, 37);
-    plot_bitmap_32(base, 234, 102, arrow_32, 37);
+    plot_bitmap_32(base, 100, 100, checkerboard_32, 32);
+    plot_bitmap_32(base, 132, 101, checkerboard_32, 32);
+    plot_bitmap_32(base, 164, 102, checkerboard_32, 32);
 
-    /* Test 9: Bounds checking - LEFT EDGE offsets (safe vertical: y=50-100) */
-    clear_screen((UINT32 *)base);
+    /* Test 9: Bounds checking - LEFT EDGE offsets (safe verItical: y=50-100) */
     plot_bitmap_32(base, 50, -32, solid_block_32, 8);  /* x=-32: fully off left */
     plot_bitmap_32(base, 60, -30, checkerboard_32, 8); /* x=-30: 30px off */
     plot_bitmap_32(base, 70, -28, frame_32, 16);       /* x=-28: 28px off */

--- a/src/raster/test.c
+++ b/src/raster/test.c
@@ -444,10 +444,10 @@ void test_plot_bitmap_8(UINT8 *base)
     plot_bitmap_8(base, 10, 25, smiley, 8);
 
     /* Test 4: Various positions across the screen */
-    plot_bitmap_8(base, 30, 0, cross, 8);
-    plot_bitmap_8(base, 30, 10, diagonal, 8);
-    plot_bitmap_8(base, 30, 20, checkerboard, 8);
-    plot_bitmap_8(base, 30, 30, smiley, 8);
+    plot_bitmap_8(base, 100, 100, solid_block, 8);
+    plot_bitmap_8(base, 108, 101, solid_block, 8);
+    plot_bitmap_8(base, 116, 102, solid_block, 8);
+    plot_bitmap_8(base, 30, 30, solid_block, 8);
 
     /* Test 5: Larger bitmap (even height, optimized) */
     plot_bitmap_8(base, 50, 8, arrow_down, 16);
@@ -598,9 +598,9 @@ void test_plot_bitmap_16(UINT8 *base)
     plot_bitmap_16(base, 10, 48, smiley_16, 16);
 
     /* Test 4: Various positions across the screen */
-    plot_bitmap_16(base, 30, 0, frame_16, 16);
-    plot_bitmap_16(base, 30, 20, diamond_16, 16);
-    plot_bitmap_16(base, 30, 40, checkerboard_16, 8);
+    plot_bitmap_16(base, 100, 100, solid_block_16, 16);
+    plot_bitmap_16(base, 116, 101, solid_block_16, 16);
+    plot_bitmap_16(base, 132, 102, solid_block_16, 8);
 
     /* Test 5: Multiple bitmaps in a row */
     plot_bitmap_16(base, 60, 0, solid_block_16, 8);
@@ -625,7 +625,6 @@ void test_plot_bitmap_16(UINT8 *base)
     plot_bitmap_16(base, 170, 48, diamond_16, 16);
 
     /* Test 9: Bounds checking - LEFT EDGE offsets (safe vertical: y=50-100) */
-    clear_screen((UINT32 *)base);
     plot_bitmap_16(base, 50, -16, solid_block_16, 8);  /* x=-16: 16px off */
     plot_bitmap_16(base, 60, -14, checkerboard_16, 8); /* x=-14: 14px off */
     plot_bitmap_16(base, 70, -12, frame_16, 16);       /* x=-12: 12px off */

--- a/src/raster/test.c
+++ b/src/raster/test.c
@@ -810,9 +810,9 @@ void test_plot_bitmap_32(UINT8 *base)
     plot_bitmap_32(base, 140, 0, smiley_32, 15);
 
     /* Test 8: Various positions testing alignment */
-    plot_bitmap_32(base, 170, 0, arrow_32, 37);
-    plot_bitmap_32(base, 170, 48, arrow_32, 37);
-    plot_bitmap_32(base, 170, 96, arrow_32, 37);
+    plot_bitmap_32(base, 170, 100, arrow_32, 37);
+    plot_bitmap_32(base, 202, 101, arrow_32, 37);
+    plot_bitmap_32(base, 234, 102, arrow_32, 37);
 
     /* Test 9: Bounds checking - LEFT EDGE offsets (safe vertical: y=50-100) */
     clear_screen((UINT32 *)base);

--- a/src/raster/test.c
+++ b/src/raster/test.c
@@ -34,6 +34,37 @@ void test_clear_region(UINT8 *base)
 
     /* Test 6: Odd column alignment to test byte spanning */
     clear_region((UINT32 *)base, 200, 5, 15, 4);
+
+    /* Test 7: Non-byte-aligned edge masking with 8-pixel width - stacked with 1-pixel offset */
+    /* Draw solid rectangles to clear over */
+    plot_rectangle((UINT32 *)base, 250, 50, 8, 16);
+    plot_rectangle((UINT32 *)base, 258, 50, 8, 16);
+    plot_rectangle((UINT32 *)base, 266, 50, 8, 16);
+
+    /* Clear regions over them, each 1 pixel offset to test edge masking */
+    clear_region((UINT32 *)base, 250, 50, 8, 8);
+    clear_region((UINT32 *)base, 258, 51, 8, 8);
+    clear_region((UINT32 *)base, 266, 52, 8, 8);
+
+    /* Test 8: Non-byte-aligned edge masking with 16-pixel width - stacked with 1-pixel offset */
+    plot_rectangle((UINT32 *)base, 250, 100, 16, 32);
+    plot_rectangle((UINT32 *)base, 266, 100, 16, 32);
+    plot_rectangle((UINT32 *)base, 282, 100, 16, 32);
+
+    /* Clear regions over them, each 1 pixel offset to test edge masking */
+    clear_region((UINT32 *)base, 250, 100, 16, 16);
+    clear_region((UINT32 *)base, 266, 101, 16, 16);
+    clear_region((UINT32 *)base, 282, 102, 16, 16);
+
+    /* Test 9: Non-byte-aligned edge masking with 32-pixel width - stacked with 1-pixel offset */
+    plot_rectangle((UINT32 *)base, 250, 200, 32, 48);
+    plot_rectangle((UINT32 *)base, 282, 200, 32, 48);
+    plot_rectangle((UINT32 *)base, 314, 200, 32, 48);
+
+    /* Clear regions over them, each 1 pixel offset to test edge masking */
+    clear_region((UINT32 *)base, 250, 200, 32, 32);
+    clear_region((UINT32 *)base, 282, 201, 32, 32);
+    clear_region((UINT32 *)base, 314, 202, 32, 32);
 }
 
 void test_plot_pixel(UINT8 *base)


### PR DESCRIPTION
### Changes

- Fix the partial-byte writing to screen buffer for non-byte aligned coordinates. This patch was applied to the following routines: `bitmap_32`, `bitmap_16`, `bitmap_8`
- Two movem optimizations
- Added visual validation of bit by bit stepping and accurate coordinates for 32/16/8 bit_map routines
- Patch partial-byte for clear_region

This hot-fix addresses the bug that caused bitmaps to "jump" every 8 bits