### PR TITLE
implement triangle drawing in all directions

### DIFF
--- a/src/raster/plt_tri.s
+++ b/src/raster/plt_tri.s
@@ -22,92 +22,78 @@
         xdef    _plot_triangle
         xref    _plot_horizontal_line
 
-base    equ     8                               ; UINT32* (4 bytes)
-row     equ     12                              ; UINT16 (2 bytes)
-col     equ     14                              ; UINT16 (2 bytes)
-base_tri equ    16                              ; UINT16 (2 bytes)
-height  equ     18                              ; UINT16 (2 bytes)
-direction equ   20                              ; UINT8 (1 byte, but padded to 2)
-
+base        equ     8                               ; UINT32* (4 bytes)
+row         equ     12                              ; UINT16 (2 bytes)
+col         equ     14                              ; UINT16 (2 bytes)
+base_tri    equ     16                              ; UINT16 (2 bytes)
+height      equ     18                              ; UINT16 (2 bytes)
+direction   equ     20                              ; UINT8 (1 byte, but padded to 2)
 
 _plot_triangle:
         link    a6,#0
-        movem.l d0-d7/a0-a6,-(sp)
+        movem.l d0-d7/a0-a1,-(sp)
                 
-                ; Check direction and branch
-        move.b  direction(a6),d0
-        andi.w  #$ff,d0                         ; clear upper byte
+        ; Check height and direction
+        move.w  height(a6),d7                       ; d7 = total height
+        beq     done                                ; if height = 0, exit
+        
+        move.w  direction(a6),d0
+        andi.w  #3,d0                               ; mask to 4 valid directions (0,1,2,3)
+        
         cmpi.w  #0,d0
         beq     dir_top_left
         cmpi.w  #1,d0
         beq     dir_top_right
         cmpi.w  #2,d0
         beq     dir_bottom_left
-        cmpi.w  #3,d0
-        beq     dir_bottom_right
-        bra     done                            ; invalid direction
+        bra     dir_bottom_right
 
 dir_top_left:
-                ; Direction 0: 90° angle at top-left
-                ; Triangle expands rightward and downward
-                ; Row i has line of length: (base * (i+1)) / height
+        ; Direction 0: 90° angle at top-left
+        ; Triangle expands rightward and downward
+        ; Row i has line of length: (base * (height - i)) / height
                 
-        move.w  height(a6),d7                   ; loop counter
-        beq     done                            ; if height = 0, exit
-        subq.w  #1,d7                           ; adjust for dbra
-        moveq   #0,d6                           ; current row offset (0 to height-1)
+        moveq   #0,d6                               ; current row offset (0 to height-1)
+        subq.w  #1,d7                               ; adjust for dbra
                 
-tl_loop:                                        ; Calculate line length: (base_tri * (d6 + 1)) / height
-        move.w  d6,d0
-        addq.w  #1,d0                           ; d0 = row_offset + 1
-        move.w  base_tri(a6),d1
-        mulu.w  d1,d0                           ; d0 = base * (row_offset + 1)
-        move.w  height(a6),d1
-        divu.w  d1,d0                           ; d0 = (base * (row_offset + 1)) / height
+tl_loop:
+        bsr     calc_length                         ; d0 = calculated line length
+        
+        move.w  row(a6),d1
+        add.w   d6,d1                               ; current_row = row + d6
                 
-                ; Draw horizontal line at (row + d6, col, length = d0)
-        move.w  row(a6),d2
-        add.w   d6,d2                           ; current_row = row + d6
-                
-                ; Call plot_horizontal_line(base, current_row, col, length)
-        move.w  d0,-(sp)                        ; push length
-        move.w  col(a6),-(sp)                   ; push col
-        move.w  d2,-(sp)                        ; push current_row
-        move.l  base(a6),-(sp)                  ; push base
+        ; Call plot_horizontal_line(base, current_row, col, length)
+        move.w  d0,-(sp)                            ; push length
+        move.w  col(a6),-(sp)                       ; push col
+        move.w  d1,-(sp)                            ; push current_row
+        move.l  base(a6),-(sp)                      ; push base
         jsr     _plot_horizontal_line
-        adda.w  #10,sp                          ; clean up stack (4+2+2+2)
+        adda.w  #10,sp                              ; clean up stack (4+2+2+2)
                 
-        addq.w  #1,d6                           ; increment row offset
+        addq.w  #1,d6                               ; increment row offset
         dbra    d7,tl_loop
         bra     done
 
 dir_top_right:
-                ; Direction 1: 90° angle at top-right
-                ; Triangle expands leftward and downward
-                ; Row i has line of length: (base * (i+1)) / height, ending at col
+        ; Direction 1: 90° angle at top-right
+        ; Triangle expands leftward and downward
                 
-        move.w  height(a6),d7
-        beq     done
-        subq.w  #1,d7
-        moveq   #0,d6
+        moveq   #0,d6                               ; current row offset
+        subq.w  #1,d7                               ; adjust for dbra
                 
-tr_loop: move.w d6,d0
-        addq.w  #1,d0
-        move.w  base_tri(a6),d1
-        mulu.w  d1,d0
-        move.w  height(a6),d1
-        divu.w  d1,d0                           ; d0 = line length
+tr_loop:
+        bsr     calc_length                         ; d0 = calculated line length
+        
+        move.w  row(a6),d1
+        add.w   d6,d1                               ; current_row = row + d6
+        
+        move.w  col(a6),d2
+        sub.w   d0,d2                               ; start_col = col - length
                 
-        move.w  row(a6),d2
-        add.w   d6,d2                           ; current_row
-                
-        move.w  col(a6),d3
-        sub.w   d0,d3                           ; start_col = col - length
-                
-                ; Call plot_horizontal_line(base, current_row, start_col, length)
+        ; Call plot_horizontal_line(base, current_row, start_col, length)
         move.w  d0,-(sp)
-        move.w  d3,-(sp)
         move.w  d2,-(sp)
+        move.w  d1,-(sp)
         move.l  base(a6),-(sp)
         jsr     _plot_horizontal_line
         adda.w  #10,sp
@@ -117,70 +103,74 @@ tr_loop: move.w d6,d0
         bra     done
 
 dir_bottom_left:
-                ; Direction 2: 90° angle at bottom-left
-                ; Triangle expands rightward and upward
-                ; Row i (from top) has line of length: (base * i) / height
+        ; Direction 2: 90° angle at bottom-left
+        ; Triangle expands rightward and upward
                 
-        move.w  height(a6),d7
-        beq     done
-        subq.w  #1,d7
-        move.w  d7,d6                           ; start from height-1, go down to 0
+        moveq   #0,d6                               ; current row offset
+        subq.w  #1,d7                               ; adjust for dbra
                 
-bl_loop: move.w d6,d0
-        addq.w  #1,d0
-        move.w  base_tri(a6),d1
-        mulu.w  d1,d0
-        move.w  height(a6),d1
-        divu.w  d1,d0                           ; d0 = line length
+bl_loop:
+        bsr     calc_length                         ; d0 = calculated line length
+        
+        move.w  row(a6),d1
+        sub.w   d6,d1                               ; current_row = row - d6 (going upward)
                 
-        move.w  row(a6),d2
-        sub.w   d6,d2                           ; current_row = row - d6 (going upward)
-                
-                ; Call plot_horizontal_line(base, current_row, col, length)
+        ; Call plot_horizontal_line(base, current_row, col, length)
         move.w  d0,-(sp)
         move.w  col(a6),-(sp)
-        move.w  d2,-(sp)
+        move.w  d1,-(sp)
         move.l  base(a6),-(sp)
         jsr     _plot_horizontal_line
         adda.w  #10,sp
                 
-        dbra    d6,bl_loop
+        addq.w  #1,d6
+        dbra    d7,bl_loop
         bra     done
 
 dir_bottom_right:
-                ; Direction 3: 90° angle at bottom-right
-                ; Triangle expands leftward and upward
+        ; Direction 3: 90° angle at bottom-right
+        ; Triangle expands leftward and upward
                 
-        move.w  height(a6),d7
-        beq     done
-        subq.w  #1,d7
-        move.w  d7,d6
+        moveq   #0,d6                               ; current row offset
+        subq.w  #1,d7                               ; adjust for dbra
                 
-br_loop: move.w d6,d0
-        addq.w  #1,d0
-        move.w  base_tri(a6),d1
-        mulu.w  d1,d0
-        move.w  height(a6),d1
-        divu.w  d1,d0                           ; d0 = line length
+br_loop:
+        bsr     calc_length                         ; d0 = calculated line length
+        
+        move.w  row(a6),d1
+        sub.w   d6,d1                               ; current_row = row - d6 (going upward)
+        
+        move.w  col(a6),d2
+        sub.w   d0,d2                               ; start_col = col - length
                 
-        move.w  row(a6),d2
-        sub.w   d6,d2                           ; current_row = row - d6
-                
-        move.w  col(a6),d3
-        sub.w   d0,d3                           ; start_col = col - length
-                
-                ; Call plot_horizontal_line(base, current_row, start_col, length)
+        ; Call plot_horizontal_line(base, current_row, start_col, length)
         move.w  d0,-(sp)
-        move.w  d3,-(sp)
         move.w  d2,-(sp)
+        move.w  d1,-(sp)
         move.l  base(a6),-(sp)
         jsr     _plot_horizontal_line
         adda.w  #10,sp
                 
-        dbra    d6,br_loop
+        addq.w  #1,d6
+        dbra    d7,br_loop
+        bra     done
+
+
+; ---------------------------------------------------------------
+; Helper Routine: calc_length
+; Calculates the length of the horizontal line for the current row
+; Equation: d0 = (base_tri * (height - d6)) / height
+; ---------------------------------------------------------------
+calc_length:
+        move.w  height(a6),d0
+        sub.w   d6,d0                               ; d0 = remaining height
+        mulu.w  base_tri(a6),d0                     ; d0 = base_tri * remaining height
+        divu.w  height(a6),d0                       ; d0 = (base_tri * remaining height) / total height
+        rts
 
 done:
-        movem.l (sp)+,d0-d7/a0-a6
+        movem.l (sp)+,d0-d7/a0-a1
         unlk    a6
         rts
 
+        

--- a/src/tests/raster/tplt_tri.c
+++ b/src/tests/raster/tplt_tri.c
@@ -90,5 +90,7 @@ int main(void) {
     RUN_TEST(test_plot_triangle_basic);
     RUN_TEST(test_plot_triangle_all_directions);
     
+    test_plot_triangle_all_directions();
+
     return UNITY_END();
 }

--- a/src/tests/raster/tplt_tri.c
+++ b/src/tests/raster/tplt_tri.c
@@ -35,16 +35,16 @@ void test_plot_triangle_basic(void) {
     /* 90-degree angle at (10, 10), base 10, height 10, Direction 0 */
     plot_triangle(mock_screen, 10, 10, 10, 10, 0);
 
-    /* Verify the tip (first row) has a minimal width */
-    /* Formula: (10 * (0 + 1)) / 10 = 1 pixel */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(mock_screen, 10, 10));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(mock_screen, 10, 11));
+    /* Verify the base (first row at the 90-degree corner) has full width */
+    /* Formula: (10 * (10 - 0)) / 10 = 10 pixels */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 10, 10), "Top-Left (Base): start pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 10, 19), "Top-Left (Base): end pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 10, 20), "Top-Left (Base): overdrawn past width");
 
-    /* Verify the base (last row, offset 9) has full width */
-    /* Formula: (10 * (9 + 1)) / 10 = 10 pixels */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(mock_screen, 19, 10));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(mock_screen, 19, 19));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(mock_screen, 19, 20));
+    /* Verify the tip (last row, offset 9) has a minimal width */
+    /* Formula: (10 * (10 - 9)) / 10 = 1 pixel */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 19, 10), "Top-Left (Tip): tip pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 19, 11), "Top-Left (Tip): overdrawn past tip width");
 }
 
 /* Implement test_plot_triangle_all_directions
@@ -53,15 +53,34 @@ void test_plot_triangle_basic(void) {
 void test_plot_triangle_all_directions(void) {
     /* 1. Top-Right (Direction 1): Expands left and down */
     plot_triangle(mock_screen, 30, 50, 10, 10, 1);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 31, 51), "Top-Right expansion failed");
+    /* Base at row 30, spans col 40 to 49 (col - length to col - 1) */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 30, 40), "Top-Right base expansion failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 30, 49), "Top-Right base anchor failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 30, 50), "Top-Right base overdrawn right");
+    /* Tip at row 39, spans col 49 to 49 */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 39, 49), "Top-Right tip failed");
+
+    /* Clear screen between direction tests */
+    memset(mock_screen, 0x00, SCREEN_SIZE_BYTES);
 
     /* 2. Bottom-Left (Direction 2): Expands right and up */
-    plot_triangle(mock_screen, 100, 10, 10, 10, 0);
-    /* TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 99, 12), "Bottom-Left start failed"); */
+    plot_triangle(mock_screen, 100, 10, 10, 10, 2);
+    /* Base at row 100, spans col 10 to 19 */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 100, 10), "Bottom-Left base start failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 100, 19), "Bottom-Left base end failed");
+    /* Tip at row 91 (100 - 9), spans col 10 to 10 */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 91, 10), "Bottom-Left tip failed");
+
+    /* Clear screen between direction tests */
+    memset(mock_screen, 0x00, SCREEN_SIZE_BYTES);
 
     /* 3. Bottom-Right (Direction 3): Expands left and up */
     plot_triangle(mock_screen, 200, 50, 10, 10, 3);
-    /* TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 199, 51), "Bottom-Right expansion failed"); */
+    /* Base at row 200, spans col 40 to 49 */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 200, 40), "Bottom-Right base expansion failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 200, 49), "Bottom-Right base anchor failed");
+    /* Tip at row 191 (200 - 9), spans col 49 to 49 */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 191, 49), "Bottom-Right tip failed");
 }
 
 /* Main function to run all tests */

--- a/src/tests/raster/tplt_tri.c
+++ b/src/tests/raster/tplt_tri.c
@@ -10,7 +10,7 @@
 static UINT32 mock_screen[SCREEN_SIZE_BYTES / 4];
 
 /* Helper to check if a single pixel at (row, col) is black (0) or white (1) */
-static int get_pixel(UINT32 *base, INT16 row, INT16 col)
+static int get_byte(UINT32 *base, INT16 row, INT16 col)
 {
     /* Cast to UINT32 to prevent 16-bit signed integer overflow during multiplication */
     UINT32 offset = ((UINT32)row * SCREEN_WIDTH_BYTES) + (col / 8);
@@ -40,14 +40,14 @@ void test_plot_triangle_basic(void) {
 
     /* Verify the base (first row at the 90-degree corner) has full width */
     /* Formula: (10 * (10 - 0)) / 10 = 10 pixels */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 10, 10), "Top-Left (Base): start pixel missing");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 10, 19), "Top-Left (Base): end pixel missing");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 10, 20), "Top-Left (Base): overdrawn past width");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 10, 10), "Top-Left (Base): start pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 10, 19), "Top-Left (Base): end pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_byte(mock_screen, 10, 20), "Top-Left (Base): overdrawn past width");
 
     /* Verify the tip (last row, offset 9) has a minimal width */
     /* Formula: (10 * (10 - 9)) / 10 = 1 pixel */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 19, 10), "Top-Left (Tip): tip pixel missing");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 19, 11), "Top-Left (Tip): overdrawn past tip width");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 19, 10), "Top-Left (Tip): tip pixel missing");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_byte(mock_screen, 19, 11), "Top-Left (Tip): overdrawn past tip width");
 }
 
 /* Implement test_plot_triangle_all_directions
@@ -57,11 +57,11 @@ void test_plot_triangle_all_directions(void) {
     /* 1. Top-Right (Direction 1): Expands left and down */
     plot_triangle(mock_screen, 30, 50, 10, 10, 1);
     /* Base at row 30, spans col 40 to 49 (col - length to col - 1) */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 30, 40), "Top-Right base expansion failed");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 30, 49), "Top-Right base anchor failed");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_pixel(mock_screen, 30, 50), "Top-Right base overdrawn right");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 30, 40), "Top-Right base expansion failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 30, 49), "Top-Right base anchor failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, get_byte(mock_screen, 30, 50), "Top-Right base overdrawn right");
     /* Tip at row 39, spans col 49 to 49 */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 39, 49), "Top-Right tip failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 39, 49), "Top-Right tip failed");
 
     /* Clear screen between direction tests */
     memset(mock_screen, 0x00, SCREEN_SIZE_BYTES);
@@ -69,10 +69,10 @@ void test_plot_triangle_all_directions(void) {
     /* 2. Bottom-Left (Direction 2): Expands right and up */
     plot_triangle(mock_screen, 100, 10, 10, 10, 2);
     /* Base at row 100, spans col 10 to 19 */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 100, 10), "Bottom-Left base start failed");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 100, 19), "Bottom-Left base end failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 100, 10), "Bottom-Left base start failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 100, 19), "Bottom-Left base end failed");
     /* Tip at row 91 (100 - 9), spans col 10 to 10 */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 91, 10), "Bottom-Left tip failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 91, 10), "Bottom-Left tip failed");
 
     /* Clear screen between direction tests */
     memset(mock_screen, 0x00, SCREEN_SIZE_BYTES);
@@ -80,10 +80,10 @@ void test_plot_triangle_all_directions(void) {
     /* 3. Bottom-Right (Direction 3): Expands left and up */
     plot_triangle(mock_screen, 200, 50, 10, 10, 3);
     /* Base at row 200, spans col 40 to 49 */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 200, 40), "Bottom-Right base expansion failed");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 200, 49), "Bottom-Right base anchor failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 200, 40), "Bottom-Right base expansion failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 200, 49), "Bottom-Right base anchor failed");
     /* Tip at row 191 (200 - 9), spans col 49 to 49 */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, 191, 49), "Bottom-Right tip failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_byte(mock_screen, 191, 49), "Bottom-Right tip failed");
 }
 
 /* Main function to run all tests */

--- a/src/tests/raster/tplt_tri.c
+++ b/src/tests/raster/tplt_tri.c
@@ -12,7 +12,10 @@ static UINT32 mock_screen[SCREEN_SIZE_BYTES / 4];
 /* Helper to check if a single pixel at (row, col) is black (0) or white (1) */
 static int get_pixel(UINT32 *base, INT16 row, INT16 col)
 {
-    UINT8 *byte_ptr = (UINT8 *)base + (row * SCREEN_WIDTH_BYTES) + (col / 8);
+    /* Cast to UINT32 to prevent 16-bit signed integer overflow during multiplication */
+    UINT32 offset = ((UINT32)row * SCREEN_WIDTH_BYTES) + (col / 8);
+    UINT8 *byte_ptr = (UINT8 *)base + offset;
+    
     int bit_pos = 7 - (col % 8);
     return (*byte_ptr >> bit_pos) & 1;
 }
@@ -90,7 +93,5 @@ int main(void) {
     RUN_TEST(test_plot_triangle_basic);
     RUN_TEST(test_plot_triangle_all_directions);
     
-    test_plot_triangle_all_directions();
-
     return UNITY_END();
 }


### PR DESCRIPTION
Updated triangle drawing and the test file to test for all directions. Fixes #110.

"Describe the bug
The triangles are supposed to be drawn in different ways based off of the direction parameter. @sudonym-i was not aware of this at the time of writing

Expected behavior
The triangles should be drawn different (ie, 90 degrees flipped based off of the parameter value) based on the direction parameter.

Additional context
This is in te plt_tri.s
Note

Raster test must be updated for this new functionality, and will be used to verify it"