### PR TITLE
Issue 116: Patch clr_reg bug on 32 non-byte-aligned

### DIFF
--- a/src/raster/clr_reg.s
+++ b/src/raster/clr_reg.s
@@ -87,7 +87,7 @@ check_alignment:
         move.w  width(a6),d0
         cmpi.w  #32,d0                          ; check if exactly 32 pixels
         bne     unoptimized
-                
+
                 ; Ensure word alignment for move.l (address must be even)
         move.l  a0,d1
         btst    #0,d1                           ; test if address is odd

--- a/src/raster/clr_reg.s
+++ b/src/raster/clr_reg.s
@@ -88,6 +88,11 @@ check_alignment:
         cmpi.w  #32,d0                          ; check if exactly 32 pixels
         bne     unoptimized
 
+                ; 32-pixel fast path only valid when col is byte-aligned
+        move.w  col(a6),d0
+        andi.w  #7,d0                           ; d0 = col % 8
+        bne     unoptimized
+
                 ; Ensure word alignment for move.l (address must be even)
         move.l  a0,d1
         btst    #0,d1                           ; test if address is odd

--- a/src/tests/raster/tclr_reg.c
+++ b/src/tests/raster/tclr_reg.c
@@ -2,6 +2,9 @@
 #include "raster.h"
 #include <string.h>
 
+#define WHITE 0
+#define BLACK 1
+
 #define SCREEN_SIZE_BYTES 32000
 #define SCREEN_SIZE_LONGS (SCREEN_SIZE_BYTES / 4)
 #define SCREEN_WIDTH_BYTES 80
@@ -12,16 +15,28 @@ static UINT32 mock_screen[SCREEN_SIZE_LONGS];
 
 extern void clear_region(UINT32 *base, INT16 row, INT16 col, UINT16 length, UINT16 width);
 
-/* Helper to check if a pixel at (row, col) is black (0) or white (1) */
+/* Helper to check if a pixel at (row, col) is white (0) or black (1) */
 static int get_pixel(UINT8 *base, INT16 row, INT16 col) {
     UINT8 *byte_ptr = base + (row * SCREEN_WIDTH_BYTES) + (col / 8);
     int bit_pos = 7 - (col % 8);
     return (*byte_ptr >> bit_pos) & 1;
 }
 
+/* Helper to set a pixel at (row, col) to 0 or 1 */
+static void set_pixel(UINT8 *base, INT16 row, INT16 col, int value) {
+    UINT8 *byte_ptr = base + (row * SCREEN_WIDTH_BYTES) + (col / 8);
+    UINT8 bit_mask = (UINT8)(1u << (7 - (col % 8)));
+
+    if (value) {
+        *byte_ptr |= bit_mask;
+    } else {
+        *byte_ptr &= (UINT8)(~bit_mask);
+    }
+}
+
 /* Setup - runs before each test */
 void setUp(void) {
-    /* Initialize screen with all white (0xFF) */
+    /* Initialize screen with all black */
     memset(mock_screen, 0xFF, SCREEN_SIZE_BYTES);
 }
 
@@ -37,15 +52,15 @@ void test_clear_region_at_origin(void) {
     /* Clear a 16x16 region at (0,0) */
     clear_region(mock_screen, 0, 0, 16, 16);
     
-    /* Verify the region is black */
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 0, 0));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 0, 15));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 15, 0));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 15, 15));
+    /* Verify the region is white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 0, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 0, 15));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 15, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 15, 15));
     
-    /* Verify pixels outside the region are still white */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 0, 16));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 16, 0));
+    /* Verify pixels outside the region are still black */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 0, 16));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 16, 0));
 }
 
 /* Test clearing a region with odd dimensions */
@@ -56,16 +71,16 @@ void test_clear_region_odd_dimensions(void) {
     clear_region(mock_screen, 10, 5, 13, 7);
     
     /* Check corners of cleared region */
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 10, 5));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 10, 11));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 22, 5));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 22, 11));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 10, 5));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 10, 11));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 22, 5));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 22, 11));
     
     /* Check pixels just outside the region */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 9, 5));   /* Above */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 10, 4));  /* Left */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 10, 12)); /* Right */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 23, 5));  /* Below */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 9, 5));   /* Above */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 10, 4));  /* Left */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 10, 12)); /* Right */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 23, 5));  /* Below */
 }
 
 /* Test clearing a 48x48 optimized region (word-aligned) */
@@ -75,15 +90,15 @@ void test_clear_region_48x48_optimized(void) {
     /* Clear a 48x48 region at word-aligned position (0,0). */
     clear_region(mock_screen, 0, 0, 48, 48);
     
-    /* Verify corners are black */
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 0, 0));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 0, 47));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 47, 0));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 47, 47));
+    /* Verify corners are white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 0, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 0, 47));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 47, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 47, 47));
     
-    /* Verify outside is white */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 0, 48));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 48, 0));
+    /* Verify outside is black */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 0, 48));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 48, 0));
 }
 
 /* Test clearing a single pixel region */
@@ -93,14 +108,58 @@ void test_clear_region_single_pixel(void) {
     /* Clear a 1x1 region at (50,100) */
     clear_region(mock_screen, 50, 100, 1, 1);
     
-    /* Verify the pixel is black */
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 50, 100));
+    /* Verify the pixel is white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 50, 100));
     
-    /* Verify adjacent pixels are white */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 50, 99));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 50, 101));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 49, 100));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 51, 100));
+    /* Verify adjacent pixels are black */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 50, 99));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 50, 101));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 49, 100));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 51, 100));
+}
+
+/**
+ * This test ensures a previous bug is caught. When region was 32 pixels wide
+ * it would assume that it was also byte aligned, and it would not properly
+ * clear the trailing pixels / ones to the right.
+ */
+void test_clear_region_width32_non_byte_aligned_column(void) {
+    UINT8 *base = (UINT8 *)mock_screen;
+    INT16 row;
+    INT16 column;
+
+    /* 34x34 region set black to check boundaries and clearing */
+    for (row = 19; row < 53; row++) {
+        for (column = 0; column < 34; column++) {
+            set_pixel(base, row, column, BLACK);
+        }
+    }
+
+    clear_region(mock_screen, 20, 1, 32, 32);
+
+    /* Columns to the left and right must be black */
+    for (row = 20; row < 52; row++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row, 0),
+            "Left boundary column cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row, 33),
+            "Right boundary column cleared incorrectly");
+    }
+
+    /* Rows above and below */
+    for (column = 1; column < 33; column++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, 19, column),
+            "Top boundary row cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, 52, column),
+            "Bottom boundary row cleared incorrectly");
+    }
+
+    /* Every cleared pixel should be white */
+    for (row = 20; row < 52; row++) {
+        for (column = 1; column < 33; column++) {
+            TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row, column),
+                "Pixel in clear remained");
+        }
+    }
 }
 
 /* Test all bounds clipping limits mathematically */
@@ -111,32 +170,32 @@ void test_clear_region_clipping(void) {
        Should clip the top 10 rows, leaving a 38x48 region starting at row 0. 
        Because width is still 48, it seamlessly stays in the optimized path! */
     clear_region(mock_screen, -10, 0, 48, 48);
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 0, 0));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 37, 0));
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 38, 0)); /* Row 38 remains white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 0, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 37, 0));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 38, 0)); /* Row 38 remains black */
 
     /* 2. Bottom Clip: Clear 20x16 at row 390, col 16.
        Should clip the bottom 10 rows, leaving a 10x16 region. */
     clear_region(mock_screen, 390, 16, 20, 16);
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 390, 16));
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 399, 16));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 390, 16));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 399, 16));
 
     /* 3. Left Clip: Clear 10x48 at row 100, col -16.
        Should clip 16 pixels off the left, leaving a 32-pixel wide region.
        It dynamically adjusts width to 32 and uses the unoptimized generic routine. */
     clear_region(mock_screen, 100, -16, 10, 48);
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 100, 0));  /* Start of screen is cleared */
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 100, 31)); /* Last column of new width 32 */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 100, 32)); /* Pixel 32 remains white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 100, 0));  /* Start of screen is cleared */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 100, 31)); /* Last column of new width 32 */
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 100, 32)); /* Pixel 32 remains black */
 
     /* 4. Right Clip: Clear 10x48 at row 200, col 624.
        Should clip the rightmost 32 pixels, leaving a 16-pixel wide region. */
     clear_region(mock_screen, 200, 624, 10, 48);
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 200, 624)); 
-    TEST_ASSERT_EQUAL_INT(0, get_pixel(base, 200, 639)); /* Last pixel on screen is cleared */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 200, 624)); 
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(base, 200, 639)); /* Last pixel on screen is cleared */
     
     /* Ensure the bounds on the next line are totally untouched, proving no overflow */
-    TEST_ASSERT_EQUAL_INT(1, get_pixel(base, 201, 0));
+    TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(base, 201, 0));
 }
 
 /* Main function to run all tests */
@@ -147,6 +206,7 @@ int main(void) {
     RUN_TEST(test_clear_region_odd_dimensions);
     RUN_TEST(test_clear_region_48x48_optimized);
     RUN_TEST(test_clear_region_single_pixel);
+    RUN_TEST(test_clear_region_width32_non_byte_aligned_column);
     /* RUN_TEST(test_clear_region_clipping); */
     
     return UNITY_END();


### PR DESCRIPTION
* Add regression tests to catch this
* Update a bunch of misinformation in the test file
* Fixes #116 