### PR TITLE
Minimize screen plotting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -17,10 +17,12 @@ void test_rendering(UINT8 *base, Model *model)
     int input;
     signed int current_event;
 
+    clear_screen((UINT32 *)base);
+
     for (w_iter = 0; w_iter < 400; w_iter++) {
         /* Temporary input */
         input = Cnecin();
-        printf("Input: %d\n", input);
+
         if (input == 32) {
             on_jump_request(model);
         }

--- a/src/model/model.c
+++ b/src/model/model.c
@@ -16,6 +16,7 @@ Model get_model(void) {
     model.col_max_li = 0; /* lava index, collision */
     model.world = get_world();
     model.old_cam = model.world.camera;
+    model.old_geo = model.world.geo; /* For rendering */
     return model;
 }
 
@@ -49,6 +50,7 @@ void model_update_collision(Model *model) {
 
 void model_update_camera(Model *model) {
     model->old_cam = model->world.camera; /* store old camera for computing deltas in view */
+    model->old_geo = model->world.geo;
     model_update_camera_bi(model);
     model_update_camera_si(model);
     model_update_camera_li(model);

--- a/src/model/model.c
+++ b/src/model/model.c
@@ -15,6 +15,7 @@ Model get_model(void) {
     model.col_min_li = 0; /* lava index, collision */
     model.col_max_li = 0; /* lava index, collision */
     model.world = get_world();
+    model.old_cam = model.world.camera;
     return model;
 }
 
@@ -47,6 +48,7 @@ void model_update_collision(Model *model) {
 }
 
 void model_update_camera(Model *model) {
+    model->old_cam = model->world.camera; /* store old camera for computing deltas in view */
     model_update_camera_bi(model);
     model_update_camera_si(model);
     model_update_camera_li(model);

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -25,6 +25,7 @@ typedef struct {
     unsigned int col_min_li; /* lava index, collision */
     unsigned int col_max_li; /* lava index, collision */
     Camera old_cam; /* previous frame's camera, used for computing camera deltas */
+    Geo old_geo; /* previous frame's geo, used for precise clear */
 } Model;
 
 /**

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -24,6 +24,7 @@ typedef struct {
     unsigned int col_max_si; /* spike index, collision */
     unsigned int col_min_li; /* lava index, collision */
     unsigned int col_max_li; /* lava index, collision */
+    Camera old_cam; /* previous frame's camera, used for computing camera deltas */
 } Model;
 
 /**

--- a/src/raster/plt_clp.s
+++ b/src/raster/plt_clp.s
@@ -92,12 +92,19 @@ do_plot:
         mulu.w  #80,d0                          ; row * 80 bytes
         ext.l   d0
         adda.l  d0,a0                           ; add row offset
-                
+
+                ; Extract sub-byte bit shift before computing byte offset
+        move.w  d1,d5
+        andi.w  #7,d5                           ; d5 = col % 8 (bit shift)
+
         move.w  d1,d0
         lsr.w   #3,d0                           ; col / 8
         ext.l   d0
-        adda.l  d0,a0                           ; add col offset
-                
+        adda.l  d0,a0                           ; add col byte offset
+
+        tst.w   d5
+        bne     do_plot_shifted                 ; non-byte-aligned: use shifted path
+
 calc_plot_bytes:
                 ; Calculate bytes per row of bitmap (original width)
         move.w  d4,d5                           ; original width in pixels
@@ -191,4 +198,79 @@ plot_lclip_entry:
                 
         rts
 
-        
+;----------------------------------------------------------------
+; Internal subroutine: do_plot_shifted
+; Plots a right-clipped bitmap with a non-byte-aligned column.
+; Branches here from do_plot when col % 8 != 0.
+; Input:
+;   a0 = screen base + row*80 + col/8  (byte-aligned start address)
+;   a1 = bitmap data
+;   d2 = height
+;   d3 = clipped width (in pixels)
+;   d4 = original bitmap width (in pixels)
+;   d5 = bit shift (col % 8, range 1-7)
+;----------------------------------------------------------------
+do_plot_shifted:
+        moveq   #8,d6
+        sub.w   d5,d6                           ; d6 = 8 - shift (complement)
+
+                ; Calculate orig bytes per row
+        move.w  d4,d0
+        addq.w  #7,d0
+        lsr.w   #3,d0                           ; d0 = orig bytes per row
+
+                ; Calculate clipped bytes per row
+        move.w  d3,d1
+        addq.w  #7,d1
+        lsr.w   #3,d1                           ; d1 = clipped bytes per row
+
+                ; Compute skip = orig - clipped (for bitmap row advance)
+        sub.w   d1,d0
+        ext.l   d0
+        move.l  d0,d7                           ; d7 = bytes to skip after each row
+        move.w  d1,d4                           ; d4 = clipped bytes per row
+
+        subq.w  #1,d2                           ; height - 1 for dbra
+
+shifted_do_plot_row:
+        movea.l a0,a2                           ; a2 = dest ptr for this row
+
+                ; Mask first dest byte: preserve top `shift` bits, clear sprite bits
+        moveq   #-1,d0
+        lsl.w   d6,d0                           ; d0 low byte = 0xFF << (8-shift)
+        and.b   d0,(a2)
+
+                ; First source byte: shift and OR into first dest byte, compute carry
+        moveq   #0,d0
+        move.b  (a1)+,d0                        ; d0 = first source byte (zero-extended)
+        move.w  d0,d1                           ; d1 = source copy for carry
+        lsr.w   d5,d0                           ; d0 low byte = source >> shift
+        or.b    d0,(a2)+                        ; OR into first dest byte, advance ptr
+        lsl.w   d6,d1                           ; d1 low byte = carry = source << (8-shift)
+        move.w  d1,d3                           ; d3 = carry for next dest byte
+
+                ; Process remaining source bytes
+        move.w  d4,d1                           ; d1 = total clipped bytes
+        subq.w  #2,d1                           ; dbra is inclusive; remaining count is (d4 - 1)
+        blt.s   shifted_do_plot_advance         ; if no remaining bytes, skip inner loop
+
+shifted_do_plot_byte_loop:
+        move.w  d1,-(sp)                        ; save loop counter
+        moveq   #0,d0
+        move.b  (a1)+,d0                        ; d0 = next source byte (zero-extended)
+        move.w  d0,d1                           ; d1 = source copy for new carry
+        lsr.w   d5,d0                           ; d0 = source >> shift
+        or.b    d3,d0                           ; combine: old carry | shifted source
+        move.b  d0,(a2)+                        ; write dest byte
+        lsl.w   d6,d1                           ; d1 = new carry in low byte
+        move.w  d1,d3                           ; d3 = new carry
+        move.w  (sp)+,d1                        ; restore loop counter
+        dbra    d1,shifted_do_plot_byte_loop
+
+shifted_do_plot_advance:
+        adda.l  d7,a1                           ; skip remaining bitmap bytes this row
+        adda.w  #80,a0                          ; advance screen to next row
+        dbra    d2,shifted_do_plot_row
+
+        rts
+

--- a/src/raster/plt_clp.s
+++ b/src/raster/plt_clp.s
@@ -127,7 +127,6 @@ plot_byte_loop:
         or.b    d1,(a2)+                        ; OR onto screen
 plot_byte_entry:
         dbra    d7,plot_byte_loop               ; decrement and branch if not -1
-                
                 ; Advance bitmap pointer to next row (skip remaining bytes)
         move.w  d5,d1                           ; original bytes per row
         sub.w   d6,d1                           ; bytes not copied
@@ -172,6 +171,11 @@ calc_lclip_bytes:
         move.w  d3,d4                           ; clipped width in pixels
         addq.w  #7,d4
         lsr.w   #3,d4                           ; bytes to copy
+
+                ; If skipped pixels are not byte-aligned, use shifted left-clip path
+        move.w  d5,d0
+        andi.w  #7,d0                           ; abs(col) % 8
+        bne     do_plot_left_clip_shifted
                 
                 ; Plot bitmap row by row
         subq.w  #1,d2                           ; height - 1 for dbra
@@ -185,7 +189,6 @@ plot_lclip_byte:
         or.b    d0,(a2)+                        ; OR onto screen
 plot_lclip_entry:
         dbra    d1,plot_lclip_byte              ; decrement and branch if not -1
-                
                 ; Move to next row in original bitmap (skip remaining bytes)
         move.w  d6,d1                           ; original bytes per row
         sub.w   d4,d1                           ; bytes already copied
@@ -196,6 +199,96 @@ plot_lclip_entry:
         adda.w  #80,a0                          ; next screen row
         dbra    d2,plot_lclip_row
                 
+        rts
+
+;----------------------------------------------------------------
+; Internal subroutine: do_plot_left_clip_shifted
+; Plots a left-clipped bitmap when abs(col) is not byte-aligned.
+; Input:
+;   a0 = screen base + row*80 (col is already clipped to 0)
+;   a1 = bitmap row start
+;   d2 = height
+;   d4 = clipped bytes per row
+;   d5 = pixels to skip from left
+;   d6 = original bytes per row
+;   d7 = bytes to skip from left
+;----------------------------------------------------------------
+do_plot_left_clip_shifted:
+        move.w  d3,d0
+        andi.w  #7,d0                           ; trailing visible bits in last byte (0..7)
+        movea.w d0,a3                           ; keep for per-row tail-byte masking
+
+        move.w  d5,d0
+        andi.w  #7,d0                           ; d0 = bit shift (1..7)
+        move.w  d0,d5                           ; d5 = shift
+        moveq   #8,d3
+        sub.w   d5,d3                           ; d3 = 8 - shift
+
+        subq.w  #1,d2                           ; height - 1 for dbra
+
+plot_lclip_shift_row:
+        movea.l a0,a2                           ; destination row pointer
+        movea.l a1,a4                           ; source row base
+        adda.w  d7,a4                           ; source row after byte skip
+        movea.l a1,a5                           ; source row base copy
+        adda.w  d6,a5                           ; source row end (one-past-last byte)
+
+                ; Save original last destination byte if partial tail exists
+        move.w  a3,d0
+        beq.s   plot_lclip_no_tail_save
+        move.w  d4,d1
+        subq.w  #1,d1
+        move.b  0(a2,d1.w),d0
+        move.b  d0,-(sp)
+plot_lclip_no_tail_save:
+
+        move.w  d4,d0                           ; bytes to output this row
+        subq.w  #1,d0                           ; dbra counter (inclusive)
+        blt.s   plot_lclip_shift_advance
+
+plot_lclip_shift_byte:
+        move.w  d0,-(sp)                        ; save byte-loop counter
+
+                ; curr byte (or 0 if out of source bytes)
+        moveq   #0,d1
+        cmpa.l  a5,a4
+        bge.s   plot_lclip_curr_done
+        move.b  (a4)+,d1
+plot_lclip_curr_done:
+
+                ; next byte (or 0), then combine
+        lsl.w   d5,d1                           ; curr << shift
+        moveq   #0,d0
+        cmpa.l  a5,a4
+        bge.s   plot_lclip_next_done
+        move.b  (a4),d0
+        lsr.w   d3,d0                           ; next >> (8 - shift)
+plot_lclip_next_done:
+        or.b    d0,d1
+        move.b  d1,(a2)+                        ; write composed destination byte
+
+        move.w  (sp)+,d0                        ; restore byte-loop counter
+        dbra    d0,plot_lclip_shift_byte
+
+plot_lclip_shift_advance:
+                ; Restore non-sprite low bits in last destination byte for partial tails
+        move.w  a3,d0
+        beq.s   plot_lclip_tail_done
+        move.l  #$ff,d1
+        lsr.w   d0,d1                           ; d1 low byte = preserve mask
+        move.w  d1,d0
+        not.w   d0                              ; d0 low byte = sprite-bit mask
+        and.b   d0,-1(a2)                       ; keep only sprite bits in written byte
+        moveq   #0,d0
+        move.b  (sp)+,d0                        ; original destination byte
+        and.b   d1,d0                           ; keep only preserved low bits
+        or.b    d0,-1(a2)                       ; merge original tail bits back
+plot_lclip_tail_done:
+
+        adda.w  d6,a1                           ; next source row (original stride)
+        adda.w  #80,a0                          ; next destination row
+        dbra    d2,plot_lclip_shift_row
+
         rts
 
 ;----------------------------------------------------------------

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -12,15 +12,22 @@
  */
 
 #include "render.h"
+#include <osbind.h>
 
 /* See render.h for documentation */
 void render(const Model *model, UINT8 *base) {
     unsigned int i;
     const Camera *cam = &model->world.camera;
+    const Camera *old_cam = &model->old_cam;
     int level_i = model->world.level_index;
     Level level = model->world.levels[level_i];
+    int input;
 
-    clear_screen((UINT32 *)base);
+    clear_ground(base, old_cam, model->world.ground_y);
+    clear_blocks(base, old_cam, level.blocks, model->cam_min_bi, model->cam_max_bi);
+    clear_spikes(base, old_cam, level.spikes, model->cam_min_si, model->cam_max_si);
+    clear_lava(base, old_cam, level.lava, model->cam_min_li, model->cam_max_li);
+    clear_geo(base, old_cam, &model->world.geo);
 
     render_ground(model, base);
 
@@ -37,6 +44,45 @@ void render(const Model *model, UINT8 *base) {
     }
 
     render_geo(&model->world.geo, cam, base);
+}
+
+clear_geo(UINT8 *base, const Camera *camera, const Geo *geo) {
+    int rel_x = camera_get_relative_x(camera, geo->x);
+    int rel_y = camera_get_relative_y(camera, geo->y);
+    clear_region((UINT32 *)base, rel_y, rel_x, geo->size, geo->size);
+}
+
+clear_lava(UINT8 *base, const Camera *camera, const Lava *lava, unsigned int min_li, unsigned int max_li) {
+    unsigned int i;
+    for (i = min_li; i <= max_li; i++) {
+        int rel_x = camera_get_relative_x(camera, lava[i].x);
+        int rel_y = camera_get_relative_y(camera, lava[i].y);
+        clear_region((UINT32 *)base, rel_y, rel_x, lava[i].size, lava[i].size);
+    }
+}
+
+clear_spikes(UINT8 *base, const Camera *camera, const Spike *spikes, unsigned int min_si, unsigned int max_si) {
+    unsigned int i;
+    for (i = min_si; i <= max_si; i++) {
+        int rel_x = camera_get_relative_x(camera, spikes[i].x);
+        int rel_y = camera_get_relative_y(camera, spikes[i].y);
+        clear_region((UINT32 *)base, rel_y, rel_x, spikes[i].size, spikes[i].size);
+    }
+}
+
+clear_blocks(UINT8 *base, const Camera *camera, const Block *blocks, unsigned int min_bi, unsigned int max_bi) {
+    unsigned int i;
+    for (i = min_bi; i <= max_bi; i++) {
+        int rel_x = camera_get_relative_x(camera, blocks[i].x);
+        int rel_y = camera_get_relative_y(camera, blocks[i].y);
+        clear_region((UINT32 *)base, rel_y, rel_x, blocks[i].size, blocks[i].size);
+    }
+}
+
+clear_ground(UINT8 *base, const Camera *camera, unsigned int ground_y) {
+    int rel_y = camera_get_relative_y(camera, ground_y);
+    /* Clear a 4-pixel tall rectangle across the screen width (640 px) */
+    clear_region((UINT32 *)base, rel_y, 0, 4, 640);
 }
 
 /* See render.h for documentation */

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -14,6 +14,35 @@
 #include "render.h"
 #include <osbind.h>
 
+/**
+ * floor_div8 and clear_sprite_region should not exist. Clearing is bugged
+ * and to save time, we're just going to clear a slightly larger region.
+ */
+/* Floor division by 8 using shifts, including negative values */
+static int floor_div8(int x) {
+    signed int result;
+
+    if (x >= 0) {
+        result = x >> 3;
+    } else {
+        result = -(((-x) + 7) >> 3);
+    }
+
+    return result;
+}
+/* Clear the the bytes of the surrounding sprite region */
+static void clear_sprite_region(UINT8 *base, int rel_y, int rel_x, unsigned int size) {
+    int clear_x;
+    int clear_right;
+    int clear_width;
+
+    clear_x = floor_div8(rel_x) << 3;
+    clear_right = (floor_div8(rel_x + (int)size - 1) << 3) + 7;
+    clear_width = clear_right - clear_x + 1;
+
+    clear_region((UINT32 *)base, rel_y, clear_x, size, clear_width);
+}
+
 /* See render.h for documentation */
 void render(const Model *model, UINT8 *base) {
     unsigned int i;
@@ -27,7 +56,7 @@ void render(const Model *model, UINT8 *base) {
     clear_blocks(base, old_cam, level.blocks, model->cam_min_bi, model->cam_max_bi);
     clear_spikes(base, old_cam, level.spikes, model->cam_min_si, model->cam_max_si);
     clear_lava(base, old_cam, level.lava, model->cam_min_li, model->cam_max_li);
-    clear_geo(base, old_cam, &model->world.geo);
+    clear_geo(base, old_cam, &model->old_geo); /* Needed because geo's position isn't static */
 
     render_ground(model, base);
 
@@ -44,42 +73,44 @@ void render(const Model *model, UINT8 *base) {
     }
 
     render_geo(&model->world.geo, cam, base);
+
+    input = Cnecin();
 }
 
-clear_geo(UINT8 *base, const Camera *camera, const Geo *geo) {
+void clear_geo(UINT8 *base, const Camera *camera, const Geo *geo) {
     int rel_x = camera_get_relative_x(camera, geo->x);
     int rel_y = camera_get_relative_y(camera, geo->y);
-    clear_region((UINT32 *)base, rel_y, rel_x, geo->size, geo->size);
+    clear_sprite_region(base, rel_y, rel_x, geo->size);
 }
 
-clear_lava(UINT8 *base, const Camera *camera, const Lava *lava, unsigned int min_li, unsigned int max_li) {
+void clear_lava(UINT8 *base, const Camera *camera, const Lava *lava, unsigned int min_li, unsigned int max_li) {
     unsigned int i;
     for (i = min_li; i <= max_li; i++) {
         int rel_x = camera_get_relative_x(camera, lava[i].x);
         int rel_y = camera_get_relative_y(camera, lava[i].y);
-        clear_region((UINT32 *)base, rel_y, rel_x, lava[i].size, lava[i].size);
+        clear_sprite_region(base, rel_y, rel_x, lava[i].size);
     }
 }
 
-clear_spikes(UINT8 *base, const Camera *camera, const Spike *spikes, unsigned int min_si, unsigned int max_si) {
+void clear_spikes(UINT8 *base, const Camera *camera, const Spike *spikes, unsigned int min_si, unsigned int max_si) {
     unsigned int i;
     for (i = min_si; i <= max_si; i++) {
         int rel_x = camera_get_relative_x(camera, spikes[i].x);
         int rel_y = camera_get_relative_y(camera, spikes[i].y);
-        clear_region((UINT32 *)base, rel_y, rel_x, spikes[i].size, spikes[i].size);
+        clear_sprite_region(base, rel_y, rel_x, spikes[i].size);
     }
 }
 
-clear_blocks(UINT8 *base, const Camera *camera, const Block *blocks, unsigned int min_bi, unsigned int max_bi) {
+void clear_blocks(UINT8 *base, const Camera *camera, const Block *blocks, unsigned int min_bi, unsigned int max_bi) {
     unsigned int i;
     for (i = min_bi; i <= max_bi; i++) {
         int rel_x = camera_get_relative_x(camera, blocks[i].x);
         int rel_y = camera_get_relative_y(camera, blocks[i].y);
-        clear_region((UINT32 *)base, rel_y, rel_x, blocks[i].size, blocks[i].size);
+        clear_sprite_region(base, rel_y, rel_x, blocks[i].size);
     }
 }
 
-clear_ground(UINT8 *base, const Camera *camera, unsigned int ground_y) {
+void clear_ground(UINT8 *base, const Camera *camera, unsigned int ground_y) {
     int rel_y = camera_get_relative_y(camera, ground_y);
     /* Clear a 4-pixel tall rectangle across the screen width (640 px) */
     clear_region((UINT32 *)base, rel_y, 0, 4, 640);

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -34,13 +34,23 @@ static int floor_div8(int x) {
 static void clear_sprite_region(UINT8 *base, int rel_y, int rel_x, unsigned int size) {
     int clear_x;
     int clear_right;
+    int clipped_left;
+    int clipped_right;
     int clear_width;
 
     clear_x = floor_div8(rel_x) << 3;
     clear_right = (floor_div8(rel_x + (int)size - 1) << 3) + 7;
-    clear_width = clear_right - clear_x + 1;
 
-    clear_region((UINT32 *)base, rel_y, clear_x, size, clear_width);
+    /* Keep the clippings in bounds */
+    clipped_left = (clear_x < 0) ? 0 : clear_x;
+    clipped_right = (clear_right >= SCREEN_WIDTH) ? (SCREEN_WIDTH - 1) : clear_right;
+
+    /* Keep horizontal clear bounds on-screen to avoid invalid writes */
+    /* TODO: There's bad logic in here, this shouldn't need to happen, but it can crash */
+    if (clipped_right >= clipped_left) {
+        clear_width = clipped_right - clipped_left + 1;
+        clear_region((UINT32 *)base, rel_y, clipped_left, size, clear_width);
+    }
 }
 
 /* See render.h for documentation */
@@ -73,8 +83,6 @@ void render(const Model *model, UINT8 *base) {
     }
 
     render_geo(&model->world.geo, cam, base);
-
-    input = Cnecin();
 }
 
 void clear_geo(UINT8 *base, const Camera *camera, const Geo *geo) {

--- a/src/tests/raster/tbmap_32.c
+++ b/src/tests/raster/tbmap_32.c
@@ -137,16 +137,16 @@ void tearDown(void)
 /* Test: Plot 32x32 all-white sprite at top-left */
 void test_plot_bitmap_32_top_left(void)
 {
-    /* Create a 32x32 bitmap with all bits set to black */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot at origin (0, 0) */
     plot_bitmap_32(mock_screen, 0, 0, bitmap, 32);
@@ -159,16 +159,16 @@ void test_plot_bitmap_32_top_right(void)
 {
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 32;
 
-    /* Create a 32x32 bitmap with all bits set to black */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot at top-right */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
@@ -181,16 +181,16 @@ void test_plot_bitmap_32_bottom_left(void)
 {
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 32;
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot at bottom-left */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
@@ -204,16 +204,16 @@ void test_plot_bitmap_32_bottom_right(void)
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 32;
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 32;
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot at bottom-right */
     plot_bitmap_32(mock_screen, start_row, start_col, bitmap, 32);
@@ -226,16 +226,16 @@ void test_plot_bitmap_32_off_left_edge(void)
 {
     const INT16 start_col = -16; /* Half off screen to the left */
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot sprite starting at col -16 (16 pixels off screen) */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
@@ -243,23 +243,45 @@ void test_plot_bitmap_32_off_left_edge(void)
     verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
 }
 
-/* Test: Plot 32x32 sprite partially off right edge */
-void test_plot_bitmap_32_off_right_edge(void)
+/* Test: Plot 32x32 sprite partially off right edge byte aligned */
+void test_plot_bitmap_32_off_right_edge_byte_aligned(void)
 {
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 16; /* Half off screen to the right */
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot sprite starting at col SCREEN_WIDTH_PIXELS - 16 (16 pixels off screen) */
+    plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
+    assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
+}
+
+/* Test: Plot 32x32 sprite partially off right edge not byte aligned */
+void test_plot_bitmap_32_off_right_edge_non_byte_aligned(void)
+{
+    const INT16 start_col = SCREEN_WIDTH_PIXELS - 7; /* Half off screen to the right */
+
+    const UINT32 bitmap[32] = {
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
+
+    /* Plot sprite starting at col SCREEN_WIDTH_PIXELS - 7 (7 pixels off screen) */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
     assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
     verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
@@ -270,16 +292,16 @@ void test_plot_bitmap_32_off_top_edge(void)
 {
     const INT16 start_row = -16; /* Half off screen to the top */
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };;
 
     /* Plot sprite starting at row -16 (top 16 pixels clipped) */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
@@ -292,16 +314,16 @@ void test_plot_bitmap_32_off_bottom_edge(void)
 {
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 16; /* Half off screen to the bottom */
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot sprite starting at row SCREEN_HEIGHT_PIXELS - 16 (bottom 16 pixels clipped) */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
@@ -312,16 +334,16 @@ void test_plot_bitmap_32_off_bottom_edge(void)
 /* Test: Plot 32x32 sprite completely off screen (top and bottom) */
 void test_plot_bitmap_32_completely_off_screen(void)
 {
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
     const UINT32 bitmap[32] = {
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
 
     /* Plot way above the top edge */
     plot_bitmap_32(mock_screen, -40, 0, bitmap, 32);
@@ -363,7 +385,8 @@ int main(void)
     RUN_TEST(test_plot_bitmap_32_bottom_left);
     RUN_TEST(test_plot_bitmap_32_bottom_right);
     RUN_TEST(test_plot_bitmap_32_off_left_edge);
-    RUN_TEST(test_plot_bitmap_32_off_right_edge);
+    RUN_TEST(test_plot_bitmap_32_off_right_edge_byte_aligned);
+    RUN_TEST(test_plot_bitmap_32_off_right_edge_non_byte_aligned);
     RUN_TEST(test_plot_bitmap_32_off_top_edge);
     RUN_TEST(test_plot_bitmap_32_off_bottom_edge);
     RUN_TEST(test_plot_bitmap_32_completely_off_screen);

--- a/src/tests/raster/tbmap_32.c
+++ b/src/tests/raster/tbmap_32.c
@@ -221,10 +221,32 @@ void test_plot_bitmap_32_bottom_right(void)
     verify_bitmap_32_pixels((UINT8 *)mock_screen, start_row, start_col, bitmap, 32);
 }
 
-/* Test: Plot 32x32 sprite partially off left edge */
-void test_plot_bitmap_32_off_left_edge(void)
+/* Test: Plot 32x32 sprite partially off left edge, byte aligned */
+void test_plot_bitmap_32_off_left_edge_byte_aligned(void)
 {
     const INT16 start_col = -16; /* Half off screen to the left */
+
+    const UINT32 bitmap[32] = {
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
+
+    /* Plot sprite starting at col -16 (16 pixels off screen) */
+    plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
+    assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
+}
+
+/* Test: Plot 32x32 sprite partially off left edge, non byte aligned */
+void test_plot_bitmap_32_off_left_edge_non_byte_aligned(void)
+{
+    const INT16 start_col = -15; /* Half off screen to the left, non byte aligned */
 
     const UINT32 bitmap[32] = {
         0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
@@ -384,7 +406,8 @@ int main(void)
     RUN_TEST(test_plot_bitmap_32_top_right);
     RUN_TEST(test_plot_bitmap_32_bottom_left);
     RUN_TEST(test_plot_bitmap_32_bottom_right);
-    RUN_TEST(test_plot_bitmap_32_off_left_edge);
+    RUN_TEST(test_plot_bitmap_32_off_left_edge_byte_aligned);
+    RUN_TEST(test_plot_bitmap_32_off_left_edge_non_byte_aligned);
     RUN_TEST(test_plot_bitmap_32_off_right_edge_byte_aligned);
     RUN_TEST(test_plot_bitmap_32_off_right_edge_non_byte_aligned);
     RUN_TEST(test_plot_bitmap_32_off_top_edge);

--- a/src/tests/raster/tbmap_32.c
+++ b/src/tests/raster/tbmap_32.c
@@ -42,21 +42,40 @@ static void assert_borders(
     UINT16 length,
     UINT16 width
 ) {
+    /* TODO: Logic is garbage, should be using ternary and cleaner loops */
     INT16 y;
     INT16 x;
+    const INT16 left_col = col - 1;
+    const INT16 right_col = col + width;
+    const INT16 top_row = row - 1;
+    const INT16 bottom_row = row + length;
 
     for (y = row; y < (INT16)(row + length); y++) {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, col - 1),
-            "Left boundary column cleared incorrectly");
-        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, col + width),
-            "Right boundary column cleared incorrectly");
+        if (y >= 0 && y < SCREEN_HEIGHT_PIXELS) {
+            if (left_col >= 0 && left_col < SCREEN_WIDTH_PIXELS) {
+                TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, left_col),
+                    "Left boundary column cleared incorrectly");
+            }
+
+            if (right_col >= 0 && right_col < SCREEN_WIDTH_PIXELS) {
+                TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, right_col),
+                    "Right boundary column cleared incorrectly");
+            }
+        }
     }
 
     for (x = col; x < (INT16)(col + width); x++) {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row - 1, x),
-            "Top boundary row cleared incorrectly");
-        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row + length, x),
-            "Bottom boundary row cleared incorrectly");
+        if (x >= 0 && x < SCREEN_WIDTH_PIXELS) {
+            if (top_row >= 0 && top_row < SCREEN_HEIGHT_PIXELS) {
+                TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, top_row, x),
+                    "Top boundary row cleared incorrectly");
+            }
+
+            if (bottom_row >= 0 && bottom_row < SCREEN_HEIGHT_PIXELS) {
+                TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, bottom_row, x),
+                    "Bottom boundary row cleared incorrectly");
+            }
+        }
     }
 }
 
@@ -118,8 +137,6 @@ void tearDown(void)
 /* Test: Plot 32x32 all-white sprite at top-left */
 void test_plot_bitmap_32_top_left(void)
 {
-    int row, col;
-
     /* Create a 32x32 bitmap with all bits set to black */
     const UINT32 bitmap[32] = {
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
@@ -133,26 +150,13 @@ void test_plot_bitmap_32_top_left(void)
 
     /* Plot at origin (0, 0) */
     plot_bitmap_32(mock_screen, 0, 0, bitmap, 32);
-
-    /* Verify all 32x32 pixels are black */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
-        }
-    }
-
-    /* Verify pixels outside sprite remain black */
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, 32));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 0));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 32));
+    assert_borders((UINT8 *)mock_screen, 0, 0, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, 0, bitmap, 32);
 }
 
 /* Test: Plot 32x32 all-white sprite at top-right */
 void test_plot_bitmap_32_top_right(void)
 {
-    int row, col;
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 32;
 
     /* Create a 32x32 bitmap with all bits set to black */
@@ -168,25 +172,13 @@ void test_plot_bitmap_32_top_right(void)
 
     /* Plot at top-right */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
-
-    /* Verify all 32x32 pixels are black */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, start_col + col));
-        }
-    }
-
-    /* Verify pixels just outside sprite remain white */
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, start_col - 1));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, start_col));
+    assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
 }
 
 /* Test: Plot 32x32 all-white sprite at bottom-left */
 void test_plot_bitmap_32_bottom_left(void)
 {
-    int row, col;
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 32;
 
     /* Create a 32x32 bitmap with all bits set to 1 (white) */
@@ -202,25 +194,13 @@ void test_plot_bitmap_32_bottom_left(void)
 
     /* Plot at bottom-left */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
-
-    /* Verify all 32x32 pixels are white */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, col));
-        }
-    }
-
-    /* Verify pixels just outside sprite remain white */
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, 0));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row, 32));
+    assert_borders((UINT8 *)mock_screen, start_row, 0, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, start_row, 0, bitmap, 32);
 }
 
 /* Test: Plot 32x32 all-white sprite at bottom-right */
 void test_plot_bitmap_32_bottom_right(void)
 {
-    int row, col;
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 32;
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 32;
 
@@ -237,25 +217,13 @@ void test_plot_bitmap_32_bottom_right(void)
 
     /* Plot at bottom-right */
     plot_bitmap_32(mock_screen, start_row, start_col, bitmap, 32);
-
-    /* Verify all 32x32 pixels are black */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, start_col + col));
-        }
-    }
-
-    /* Verify pixels just outside sprite remain white */
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, start_col));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row, start_col - 1));
+    assert_borders((UINT8 *)mock_screen, start_row, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, start_row, start_col, bitmap, 32);
 }
 
 /* Test: Plot 32x32 sprite partially off left edge */
 void test_plot_bitmap_32_off_left_edge(void)
 {
-    int row, col;
     const INT16 start_col = -16; /* Half off screen to the left */
 
     /* Create a 32x32 bitmap with all bits set to 1 (white) */
@@ -271,29 +239,13 @@ void test_plot_bitmap_32_off_left_edge(void)
 
     /* Plot sprite starting at col -16 (16 pixels off screen) */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
-
-    /* Verify only the right 16 pixels (columns 0-15) are drawn */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 16; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
-        }
-    }
-
-    /* Verify pixels beyond visible portion remain white */
-    for (row = 0; row < 32; row++)
-    {
-        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, row, 16));
-    }
-
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 0));
+    assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
 }
 
 /* Test: Plot 32x32 sprite partially off right edge */
 void test_plot_bitmap_32_off_right_edge(void)
 {
-    int row, col;
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 16; /* Half off screen to the right */
 
     /* Create a 32x32 bitmap with all bits set to 1 (white) */
@@ -309,28 +261,13 @@ void test_plot_bitmap_32_off_right_edge(void)
 
     /* Plot sprite starting at col SCREEN_WIDTH_PIXELS - 16 (16 pixels off screen) */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
-
-    /* Verify only the left 16 pixels are drawn (from start_col to start_col+15) */
-    for (row = 0; row < 32; row++)
-    {
-        for (col = 0; col < 15; col++)
-        {
-            TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(mock_screen, row, start_col + col), "Black failed");
-        }
-    }
-
-    /* Verify pixels before the sprite remain white */
-    for (row = 0; row < 32; row++)
-    {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(mock_screen, row, start_col - 1), "White failed");
-    }
-
+    assert_borders((UINT8 *)mock_screen, 0, start_col, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, 0, start_col, bitmap, 32);
 }
 
 /* Test: Plot 32x32 sprite partially off top edge */
 void test_plot_bitmap_32_off_top_edge(void)
 {
-    int row, col;
     const INT16 start_row = -16; /* Half off screen to the top */
 
     /* Create a 32x32 bitmap with all bits set to 1 (white) */
@@ -346,27 +283,13 @@ void test_plot_bitmap_32_off_top_edge(void)
 
     /* Plot sprite starting at row -16 (top 16 pixels clipped) */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
-
-    /* Verify only the bottom 16 pixels of the sprite (rows 0-15 on screen) are drawn */
-    for (row = 0; row < 16; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
-        }
-    }
-
-    /* Verify pixels just below the visible portion remain white */
-    for (col = 0; col < 32; col++)
-    {
-        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 16, col));
-    }
+    assert_borders((UINT8 *)mock_screen, start_row, 0, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, start_row, 0, bitmap, 32);
 }
 
 /* Test: Plot 32x32 sprite partially off bottom edge */
 void test_plot_bitmap_32_off_bottom_edge(void)
 {
-    int row, col;
     const INT16 start_row = SCREEN_HEIGHT_PIXELS - 16; /* Half off screen to the bottom */
 
     /* Create a 32x32 bitmap with all bits set to 1 (white) */
@@ -382,21 +305,8 @@ void test_plot_bitmap_32_off_bottom_edge(void)
 
     /* Plot sprite starting at row SCREEN_HEIGHT_PIXELS - 16 (bottom 16 pixels clipped) */
     plot_bitmap_32(mock_screen, start_row, 0, bitmap, 32);
-
-    /* Verify only the top 16 pixels of the sprite are drawn */
-    for (row = 0; row < 16; row++)
-    {
-        for (col = 0; col < 32; col++)
-        {
-            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, col));
-        }
-    }
-
-    /* Verify pixels just above the sprite remain white */
-    for (col = 0; col < 32; col++)
-    {
-        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, col));
-    }
+    assert_borders((UINT8 *)mock_screen, start_row, 0, 32, 32);
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, start_row, 0, bitmap, 32);
 }
 
 /* Test: Plot 32x32 sprite completely off screen (top and bottom) */
@@ -415,13 +325,11 @@ void test_plot_bitmap_32_completely_off_screen(void)
 
     /* Plot way above the top edge */
     plot_bitmap_32(mock_screen, -40, 0, bitmap, 32);
+    assert_borders((UINT8 *)mock_screen, -40, 0, 32, 32);
     
     /* Plot way below the bottom edge */
     plot_bitmap_32(mock_screen, SCREEN_HEIGHT_PIXELS + 10, 0, bitmap, 32);
-
-    /* Verify that bounds remain perfectly black, proving the draw aborted */
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, 0));
-    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, SCREEN_HEIGHT_PIXELS - 1, 0));
+    assert_borders((UINT8 *)mock_screen, SCREEN_HEIGHT_PIXELS + 10, 0, 32, 32);
 }
 
 void test_plot_bitmap_32_centered(void) {

--- a/src/tests/raster/tbmap_32.c
+++ b/src/tests/raster/tbmap_32.c
@@ -6,8 +6,8 @@
 #define SCREEN_WIDTH_BYTES 80
 #define SCREEN_WIDTH_PIXELS 640
 #define SCREEN_HEIGHT_PIXELS 400
-#define COLOR_WHITE 1
-#define COLOR_BLACK 0
+#define WHITE 0
+#define BLACK 1
 
 /* Mock screen buffer for testing */
 static UINT8 mock_screen[SCREEN_SIZE_BYTES];
@@ -22,10 +22,90 @@ static int get_pixel(UINT8 *base, INT16 row, INT16 col)
     return (*byte_ptr >> bit_pos) & 1;
 }
 
+/* Helper to set a pixel at (row, col) to 0 or 1 */
+static void set_pixel(UINT8 *base, INT16 row, INT16 col, int value) {
+    UINT8 *byte_ptr = base + (row * SCREEN_WIDTH_BYTES) + (col / 8);
+    UINT8 bit_mask = (UINT8)(1u << (7 - (col % 8)));
+
+    if (value) {
+        *byte_ptr |= bit_mask;
+    } else {
+        *byte_ptr &= (UINT8)(~bit_mask);
+    }
+}
+
+/* Seed border, clear region, and verify clear/boundary behavior. */
+static void assert_borders(
+    UINT8 *base,
+    INT16 row,
+    INT16 col,
+    UINT16 length,
+    UINT16 width
+) {
+    INT16 y;
+    INT16 x;
+
+    for (y = row; y < (INT16)(row + length); y++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, col - 1),
+            "Left boundary column cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, col + width),
+            "Right boundary column cleared incorrectly");
+    }
+
+    for (x = col; x < (INT16)(col + width); x++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row - 1, x),
+            "Top boundary row cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row + length, x),
+            "Bottom boundary row cleared incorrectly");
+    }
+}
+
+/* Read one pixel from a 32-bit bitmap row using only division/modulo math. */
+static int get_bitmap_32_pixel(const UINT32 *bitmap, INT16 row, INT16 col)
+{
+    UINT32 value = bitmap[row];
+    INT16 step;
+
+    for (step = 0; step < (INT16)(31 - col); step++) {
+        /* 2u is an unsigned int 2, avoids conversion warnings */
+        value /= 2u;
+    }
+
+    return (value % 2u) ? BLACK : WHITE;
+}
+
+/* Verify bitmap pixels exactly match expected data, with screen bounds clipping. */
+static void verify_bitmap_32_pixels(
+    UINT8 *base,
+    INT16 row,
+    INT16 col,
+    const UINT32 *bitmap,
+    UINT16 height
+) {
+    INT16 src_row;
+    INT16 src_col;
+
+    for (src_row = 0; src_row < (INT16)height; src_row++) {
+        const INT16 dst_row = row + src_row;
+
+        if (dst_row >= 0 && dst_row < SCREEN_HEIGHT_PIXELS) {
+            for (src_col = 0; src_col < 32; src_col++) {
+                const INT16 dst_col = col + src_col;
+                const int expected = get_bitmap_32_pixel(bitmap, src_row, src_col);
+
+                if (dst_col >= 0 && dst_col < SCREEN_WIDTH_PIXELS) {
+                    TEST_ASSERT_EQUAL_INT_MESSAGE(expected, get_pixel(base, dst_row, dst_col),
+                        "Bitmap pixel mismatch");
+                }
+            }
+        }
+    }
+}
+
 /* Setup - runs before each test */
 void setUp(void)
 {
-    /* Initialize screen with all zeros (black) */
+    /* Initialize screen with all white */
     memset(mock_screen, 0x00, SCREEN_SIZE_BYTES);
 }
 
@@ -40,7 +120,7 @@ void test_plot_bitmap_32_top_left(void)
 {
     int row, col;
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
+    /* Create a 32x32 bitmap with all bits set to black */
     const UINT32 bitmap[32] = {
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
@@ -54,19 +134,19 @@ void test_plot_bitmap_32_top_left(void)
     /* Plot at origin (0, 0) */
     plot_bitmap_32(mock_screen, 0, 0, bitmap, 32);
 
-    /* Verify all 32x32 pixels are white */
+    /* Verify all 32x32 pixels are black */
     for (row = 0; row < 32; row++)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, row, col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
         }
     }
 
     /* Verify pixels outside sprite remain black */
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 0, 32));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 32, 0));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 32, 32));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, 32));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 32));
 }
 
 /* Test: Plot 32x32 all-white sprite at top-right */
@@ -75,7 +155,7 @@ void test_plot_bitmap_32_top_right(void)
     int row, col;
     const INT16 start_col = SCREEN_WIDTH_PIXELS - 32;
 
-    /* Create a 32x32 bitmap with all bits set to 1 (white) */
+    /* Create a 32x32 bitmap with all bits set to black */
     const UINT32 bitmap[32] = {
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
@@ -89,18 +169,18 @@ void test_plot_bitmap_32_top_right(void)
     /* Plot at top-right */
     plot_bitmap_32(mock_screen, 0, start_col, bitmap, 32);
 
-    /* Verify all 32x32 pixels are white */
+    /* Verify all 32x32 pixels are black */
     for (row = 0; row < 32; row++)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, row, start_col + col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, start_col + col));
         }
     }
 
-    /* Verify pixels just outside sprite remain black */
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 0, start_col - 1));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 32, start_col));
+    /* Verify pixels just outside sprite remain white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, start_col - 1));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, start_col));
 }
 
 /* Test: Plot 32x32 all-white sprite at bottom-left */
@@ -128,13 +208,13 @@ void test_plot_bitmap_32_bottom_left(void)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, start_row + row, col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, col));
         }
     }
 
-    /* Verify pixels just outside sprite remain black */
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, start_row - 1, 0));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, start_row, 32));
+    /* Verify pixels just outside sprite remain white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row, 32));
 }
 
 /* Test: Plot 32x32 all-white sprite at bottom-right */
@@ -158,18 +238,18 @@ void test_plot_bitmap_32_bottom_right(void)
     /* Plot at bottom-right */
     plot_bitmap_32(mock_screen, start_row, start_col, bitmap, 32);
 
-    /* Verify all 32x32 pixels are white */
+    /* Verify all 32x32 pixels are black */
     for (row = 0; row < 32; row++)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, start_row + row, start_col + col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, start_col + col));
         }
     }
 
-    /* Verify pixels just outside sprite remain black */
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, start_row - 1, start_col));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, start_row, start_col - 1));
+    /* Verify pixels just outside sprite remain white */
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, start_col));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row, start_col - 1));
 }
 
 /* Test: Plot 32x32 sprite partially off left edge */
@@ -197,17 +277,17 @@ void test_plot_bitmap_32_off_left_edge(void)
     {
         for (col = 0; col < 16; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, row, col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
         }
     }
 
-    /* Verify pixels beyond visible portion remain black */
+    /* Verify pixels beyond visible portion remain white */
     for (row = 0; row < 32; row++)
     {
-        TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, row, 16));
+        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, row, 16));
     }
 
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 32, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 32, 0));
 }
 
 /* Test: Plot 32x32 sprite partially off right edge */
@@ -235,14 +315,14 @@ void test_plot_bitmap_32_off_right_edge(void)
     {
         for (col = 0; col < 15; col++)
         {
-            TEST_ASSERT_EQUAL_INT_MESSAGE(1, get_pixel(mock_screen, row, start_col + col), "white failed");
+            TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(mock_screen, row, start_col + col), "Black failed");
         }
     }
 
-    /* Verify pixels before the sprite remain black */
+    /* Verify pixels before the sprite remain white */
     for (row = 0; row < 32; row++)
     {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(COLOR_BLACK, get_pixel(mock_screen, row, start_col - 1), "Black failed");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(mock_screen, row, start_col - 1), "White failed");
     }
 
 }
@@ -272,14 +352,14 @@ void test_plot_bitmap_32_off_top_edge(void)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, row, col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, row, col));
         }
     }
 
-    /* Verify pixels just below the visible portion remain black */
+    /* Verify pixels just below the visible portion remain white */
     for (col = 0; col < 32; col++)
     {
-        TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 16, col));
+        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 16, col));
     }
 }
 
@@ -308,14 +388,14 @@ void test_plot_bitmap_32_off_bottom_edge(void)
     {
         for (col = 0; col < 32; col++)
         {
-            TEST_ASSERT_EQUAL_INT(COLOR_WHITE, get_pixel(mock_screen, start_row + row, col));
+            TEST_ASSERT_EQUAL_INT(BLACK, get_pixel(mock_screen, start_row + row, col));
         }
     }
 
-    /* Verify pixels just above the sprite remain black */
+    /* Verify pixels just above the sprite remain white */
     for (col = 0; col < 32; col++)
     {
-        TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, start_row - 1, col));
+        TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, start_row - 1, col));
     }
 }
 
@@ -340,8 +420,29 @@ void test_plot_bitmap_32_completely_off_screen(void)
     plot_bitmap_32(mock_screen, SCREEN_HEIGHT_PIXELS + 10, 0, bitmap, 32);
 
     /* Verify that bounds remain perfectly black, proving the draw aborted */
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, 0, 0));
-    TEST_ASSERT_EQUAL_INT(COLOR_BLACK, get_pixel(mock_screen, SCREEN_HEIGHT_PIXELS - 1, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, 0, 0));
+    TEST_ASSERT_EQUAL_INT(WHITE, get_pixel(mock_screen, SCREEN_HEIGHT_PIXELS - 1, 0));
+}
+
+void test_plot_bitmap_32_centered(void) {
+    const UINT32 bitmap[32] = {
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555,
+        0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA,
+        0x55555555, 0x55555555, 0x55555555, 0x55555555
+    };
+    int row = ((SCREEN_HEIGHT_PIXELS - 32) / 2) + 1;
+    int col = ((SCREEN_WIDTH_PIXELS - 32) / 2) + 1;
+
+    /* Plot sprite centered on the screen, but shouldn't be byte aligned */
+    plot_bitmap_32(mock_screen, row, col, bitmap, 32);
+
+    verify_bitmap_32_pixels((UINT8 *)mock_screen, row, col, bitmap, 32);
+    assert_borders((UINT8 *)mock_screen, row, col, 32, 32);
 }
 
 /* Main function to run all tests */
@@ -358,6 +459,7 @@ int main(void)
     RUN_TEST(test_plot_bitmap_32_off_top_edge);
     RUN_TEST(test_plot_bitmap_32_off_bottom_edge);
     RUN_TEST(test_plot_bitmap_32_completely_off_screen);
+    RUN_TEST(test_plot_bitmap_32_centered);
 
     return UNITY_END();
 }

--- a/src/tests/raster/tclr_reg.c
+++ b/src/tests/raster/tclr_reg.c
@@ -34,6 +34,47 @@ static void set_pixel(UINT8 *base, INT16 row, INT16 col, int value) {
     }
 }
 
+/* Seed border, clear region, and verify clear/boundary behavior. */
+static void clear_region_with_black_border_assertion(
+    UINT8 *base,
+    INT16 row,
+    INT16 col,
+    UINT16 length,
+    UINT16 width
+) {
+    INT16 y;
+    INT16 x;
+
+    for (y = row - 1; y < (INT16)(row + length + 1); y++) {
+        for (x = col - 1; x < (INT16)(col + width + 1); x++) {
+            set_pixel(base, y, x, BLACK);
+        }
+    }
+
+    clear_region(mock_screen, row, col, length, width);
+
+    for (y = row; y < (INT16)(row + length); y++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, y, col - 1),
+            "Left boundary column cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, y, col + width),
+            "Right boundary column cleared incorrectly");
+    }
+
+    for (x = col; x < (INT16)(col + width); x++) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row - 1, x),
+            "Top boundary row cleared incorrectly");
+        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row + length, x),
+            "Bottom boundary row cleared incorrectly");
+    }
+
+    for (y = row; y < (INT16)(row + length); y++) {
+        for (x = col; x < (INT16)(col + width); x++) {
+            TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, y, x),
+                "Pixel in clear remained");
+        }
+    }
+}
+
 /* Setup - runs before each test */
 void setUp(void) {
     /* Initialize screen with all black */
@@ -125,41 +166,12 @@ void test_clear_region_single_pixel(void) {
  */
 void test_clear_region_width32_non_byte_aligned_column(void) {
     UINT8 *base = (UINT8 *)mock_screen;
-    INT16 row;
-    INT16 column;
+    const INT16 region_row = 20;
+    const INT16 region_col = 1;
+    const UINT16 region_length = 32;
+    const UINT16 region_width = 32;
 
-    /* 34x34 region set black to check boundaries and clearing */
-    for (row = 19; row < 53; row++) {
-        for (column = 0; column < 34; column++) {
-            set_pixel(base, row, column, BLACK);
-        }
-    }
-
-    clear_region(mock_screen, 20, 1, 32, 32);
-
-    /* Columns to the left and right must be black */
-    for (row = 20; row < 52; row++) {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row, 0),
-            "Left boundary column cleared incorrectly");
-        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, row, 33),
-            "Right boundary column cleared incorrectly");
-    }
-
-    /* Rows above and below */
-    for (column = 1; column < 33; column++) {
-        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, 19, column),
-            "Top boundary row cleared incorrectly");
-        TEST_ASSERT_EQUAL_INT_MESSAGE(BLACK, get_pixel(base, 52, column),
-            "Bottom boundary row cleared incorrectly");
-    }
-
-    /* Every cleared pixel should be white */
-    for (row = 20; row < 52; row++) {
-        for (column = 1; column < 33; column++) {
-            TEST_ASSERT_EQUAL_INT_MESSAGE(WHITE, get_pixel(base, row, column),
-                "Pixel in clear remained");
-        }
-    }
+    clear_region_with_black_border_assertion(base, region_row, region_col, region_length, region_width);
 }
 
 /* Test all bounds clipping limits mathematically */


### PR DESCRIPTION
Fixes #99 

The code is more garbage:
1. I wouldn't be shocked if this ended up being slower than just clearing the screen
2. It does error checking that should be in assembly because there's not really time to figure out what's going wrong with the clear screen, or the plotting, I'm not really sure which. It could also be the render logic, but I'm doubtful
3. It includes #112 because I'm praying the diff will be nice once it's merged in, I should do a git revert, but it started doing some funny stuff so I left it alone
4. Because of point 2, it just clears all the bytes that a particular sprite touches, instead of individual pixels